### PR TITLE
Rename vehicles router variable

### DIFF
--- a/backend/app/vehicles/routes.py
+++ b/backend/app/vehicles/routes.py
@@ -2,7 +2,7 @@
 # This file contains routes for managing vehicles, including adding new vehicles, retrieving user vehicles,
 # and managing vehicle history and maintenance contracts.
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from app.auth.dependencies import get_current_user
 from prisma import Prisma
 from pydantic import BaseModel
@@ -16,7 +16,7 @@ from uuid import uuid4
 from app.auth.dependencies import require_role
 from app.db.prisma_client import db
 
-APIRouter = APIRouter(prefix="/vehicles", tags=["vehicles"])
+router = APIRouter(prefix="/vehicles", tags=["vehicles"])
 
 db = Prisma()
 


### PR DESCRIPTION
## Summary
- rename the FastAPI router instance in the vehicles routes module to `router`
- import `HTTPException` and `UploadFile` so route definitions have their dependencies available

## Testing
- `PYTHONPATH=. python - <<'PY'
import types, sys
prisma = types.ModuleType('prisma')
class Prisma:
    def __init__(self, *args, **kwargs):
        pass
prisma.Prisma = Prisma
sys.modules['prisma'] = prisma
import app.vehicles.routes
PY`


------
https://chatgpt.com/codex/tasks/task_e_68df15d59680832cb64cde6ddafb2ba5