### PR TITLE
Refactor calendar module and add coverage

### DIFF
--- a/backend/app/calendar/services.py
+++ b/backend/app/calendar/services.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List
+
+from app.db.prisma_client import db
+
+
+class InvalidWebhookPayload(Exception):
+    """Raised when a webhook payload is missing required fields."""
+
+
+class AppointmentNotFound(Exception):
+    """Raised when a webhook references an appointment that cannot be located."""
+
+
+def _extract(record: Any, key: str, default: Any | None = None) -> Any:
+    if isinstance(record, dict):
+        return record.get(key, default)
+    return getattr(record, key, default)
+
+
+def _format_dt(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _escape(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def generate_public_calendar_ics(technician: Any, jobs: Iterable[Any]) -> str:
+    """Create a minimal ICS calendar feed for the provided technician jobs."""
+
+    tech_name = _extract(technician, "name", "Technician")
+    calendar_lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        f"PRODID:-//RepairCRM//Calendar//EN",
+        f"X-WR-CALNAME:{_escape(str(tech_name))}",
+    ]
+
+    generated = datetime.now(timezone.utc)
+
+    for job in jobs:
+        start = _extract(job, "startTime")
+        end = _extract(job, "endTime")
+        if not isinstance(start, datetime) or not isinstance(end, datetime):
+            continue
+
+        summary = _extract(job, "title") or _extract(job, "summary") or "Service Appointment"
+        description = _extract(job, "description") or ""
+        uid = _extract(job, "id") or f"job-{_format_dt(start)}"
+        location = _extract(job, "location", "")
+
+        calendar_lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:{_escape(str(uid))}@repaircrm",
+                f"DTSTAMP:{_format_dt(generated)}",
+                f"DTSTART:{_format_dt(start)}",
+                f"DTEND:{_format_dt(end)}",
+                f"SUMMARY:{_escape(str(summary))}",
+            ]
+        )
+
+        if description:
+            calendar_lines.append(f"DESCRIPTION:{_escape(str(description))}")
+        if location:
+            calendar_lines.append(f"LOCATION:{_escape(str(location))}")
+
+        calendar_lines.append("END:VEVENT")
+
+    calendar_lines.append("END:VCALENDAR")
+    return "\r\n".join(calendar_lines) + "\r\n"
+
+
+async def process_webhook_payload(payload: Dict[str, Any]) -> None:
+    event_id = payload.get("event_id")
+    provider = payload.get("provider")
+    status = payload.get("status", "").lower()
+
+    if not event_id or not provider:
+        raise InvalidWebhookPayload("event_id and provider are required")
+
+    await db.connect()
+    try:
+        appointment = await db.appointment.find_first(
+            where={
+                "externalEventId": event_id,
+                "calendarProvider": provider.upper(),
+            }
+        )
+
+        if not appointment:
+            raise AppointmentNotFound(event_id)
+
+        appointment_id = _extract(appointment, "id")
+        if not appointment_id:
+            raise AppointmentNotFound(event_id)
+
+        update_data: Dict[str, Any] = {}
+
+        if status == "cancelled":
+            update_data["status"] = "CANCELLED"
+        elif status == "updated":
+            start = payload.get("start")
+            end = payload.get("end")
+            if isinstance(start, str):
+                update_data["startTime"] = datetime.fromisoformat(start)
+            if isinstance(end, str):
+                update_data["endTime"] = datetime.fromisoformat(end)
+
+        if update_data:
+            await db.appointment.update(where={"id": appointment_id}, data=update_data)
+    finally:
+        await db.disconnect()
+
+
+async def get_user_google_token(user_id: str) -> str:
+    await db.connect()
+    try:
+        user = await db.user.find_unique(where={"id": user_id})
+    finally:
+        await db.disconnect()
+
+    token = _extract(user, "googleRefreshToken") if user else None
+    if not token:
+        raise ValueError("Google Calendar is not linked for this user")
+    return str(token)
+
+
+async def fetch_appointments_to_sync() -> List[Any]:
+    await db.connect()
+    try:
+        appointments = await db.appointment.find_many(where={"status": "SCHEDULED"})
+    finally:
+        await db.disconnect()
+    return list(appointments)
+
+
+async def push_to_google_calendar(token: str, event: Any) -> None:
+    if not token:
+        raise ValueError("Missing Google token")
+    if event is None:
+        raise ValueError("Missing event data")
+    # In a production system this would call Google APIs. Here we simply succeed.
+
+
+async def exchange_google_code_for_token(code: str) -> Dict[str, str]:
+    if not code:
+        raise ValueError("Authorization code is required")
+
+    # Placeholder for OAuth exchange logic.
+    return {
+        "refresh_token": f"refresh-{code}",
+        "email": f"user-{code}@example.com",
+    }
+
+
+async def store_google_credentials(user_id: str, token_data: Dict[str, Any]) -> None:
+    await db.connect()
+    try:
+        await db.user.update(
+            where={"id": user_id},
+            data={
+                "googleRefreshToken": token_data.get("refresh_token"),
+                "googleEmail": token_data.get("email"),
+            },
+        )
+    finally:
+        await db.disconnect()
+

--- a/backend/tests/test_calendar_routes.py
+++ b/backend/tests/test_calendar_routes.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _PrismaStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+if "prisma" in sys.modules:
+    sys.modules["prisma"].Prisma = _PrismaStub
+else:
+    sys.modules["prisma"] = types.SimpleNamespace(Prisma=_PrismaStub)
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.calendar import routes, services  # noqa: E402
+
+
+class FakeUserTable:
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    async def find_first(self, where: Dict[str, Any]) -> Dict[str, Any] | None:
+        token = where.get("publicCalendarToken")
+        for record in self.records:
+            if record.get("publicCalendarToken") == token:
+                return dict(record)
+        return None
+
+    async def find_unique(self, where: Dict[str, Any]) -> Dict[str, Any] | None:
+        lookup = where.get("id")
+        for record in self.records:
+            if record.get("id") == lookup:
+                return dict(record)
+        return None
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        lookup = where.get("id")
+        for record in self.records:
+            if record.get("id") == lookup:
+                record.update(data)
+                return dict(record)
+        updated = {"id": lookup, **data}
+        self.records.append(updated)
+        return updated
+
+
+class FakeJobTable:
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+        self.updated: List[Dict[str, Any]] = []
+
+    async def find_many(self, where: Dict[str, Any]) -> List[Dict[str, Any]]:
+        technician = where.get("technicianId")
+        acknowledged = where.get("acknowledged")
+        results = []
+        for record in self.records:
+            if technician and record.get("technicianId") != technician:
+                continue
+            if acknowledged is not None and record.get("acknowledged") != acknowledged:
+                continue
+            results.append(dict(record))
+        return results
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        lookup = where.get("id")
+        for record in self.records:
+            if record.get("id") == lookup:
+                record.update(data)
+                self.updated.append({"where": where, "data": data})
+                return dict(record)
+        raise KeyError("Job not found")
+
+
+class FakeAppointmentTable:
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+        self.updated: List[Dict[str, Any]] = []
+
+    async def find_first(self, where: Dict[str, Any]) -> Dict[str, Any] | None:
+        external_id = where.get("externalEventId")
+        provider = where.get("calendarProvider")
+        for record in self.records:
+            if record.get("externalEventId") == external_id and record.get("calendarProvider") == provider:
+                return dict(record)
+        return None
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:
+        status = (where or {}).get("status") if where else None
+        if status:
+            return [dict(rec) for rec in self.records if rec.get("status") == status]
+        return [dict(rec) for rec in self.records]
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        lookup = where.get("id")
+        for record in self.records:
+            if record.get("id") == lookup:
+                record.update(data)
+                self.updated.append({"where": where, "data": data})
+                return dict(record)
+        raise KeyError("Appointment not found")
+
+
+class FakeWorkbayTable:
+    async def find_many(self, **_: Any) -> List[Dict[str, Any]]:
+        return []
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.connected = False
+        self.user = FakeUserTable()
+        self.job = FakeJobTable()
+        self.appointment = FakeAppointmentTable()
+        self.workbay = FakeWorkbayTable()
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+@pytest.fixture()
+def client(monkeypatch) -> TestClient:
+    fake_db = FakeDB()
+    monkeypatch.setattr(routes, "db", fake_db)
+    monkeypatch.setattr(services, "db", fake_db)
+
+    app = FastAPI()
+    app.include_router(routes.router)
+    return TestClient(app)
+
+
+def test_public_ics_marks_jobs_acknowledged(client: TestClient):
+    fake_db = routes.db  # type: ignore[assignment]
+
+    fake_db.user.records.append(
+        {
+            "id": "tech-1",
+            "name": "Alex Technician",
+            "publicCalendarToken": "token-123",
+        }
+    )
+
+    start = datetime.utcnow().replace(microsecond=0)
+    end = start + timedelta(hours=2)
+    fake_db.job.records.append(
+        {
+            "id": "job-1",
+            "technicianId": "tech-1",
+            "acknowledged": False,
+            "title": "Oil Change",
+            "description": "Routine maintenance",
+            "startTime": start,
+            "endTime": end,
+        }
+    )
+
+    response = client.get("/calendar/public/token-123.ics")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "BEGIN:VCALENDAR" in body
+    assert "SUMMARY:Oil Change" in body
+    assert fake_db.job.records[0]["acknowledged"] is True
+    assert fake_db.job.updated, "Job acknowledgement should be recorded"
+
+
+def test_webhook_updates_appointment_status(client: TestClient):
+    fake_db = routes.db  # type: ignore[assignment]
+
+    fake_db.appointment.records.append(
+        {
+            "id": "appt-1",
+            "externalEventId": "evt-123",
+            "calendarProvider": "GOOGLE",
+            "status": "SCHEDULED",
+        }
+    )
+
+    response = client.post(
+        "/calendar/webhook",
+        json={"event_id": "evt-123", "provider": "GOOGLE", "status": "cancelled"},
+    )
+
+    assert response.status_code == 200
+    assert fake_db.appointment.updated
+    assert fake_db.appointment.records[0]["status"] == "CANCELLED"
+
+
+def test_webhook_missing_event_returns_404(client: TestClient):
+    response = client.post(
+        "/calendar/webhook",
+        json={"event_id": "missing", "provider": "GOOGLE", "status": "cancelled"},
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- refactor the calendar router with a /calendar prefix and remove stray banking endpoints
- add service helpers for ICS generation, Google sync placeholders, and webhook processing used by the calendar routes
- add API tests covering public ICS feeds and webhook-driven appointment updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19531cee0832c9efbc2412a8b82c7