### PR TITLE
feat: add persistent chat messaging

### DIFF
--- a/backend/app/communication/routes.py
+++ b/backend/app/communication/routes.py
@@ -1,15 +1,25 @@
-# backend/app/communication/routes.py
-# This file contains routes for managing internal notes and chat messages between users.
-from fastapi import APIRouter, Depends, HTTPException
+"""Communication routes including chat WebSocket handling."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Optional, Set
+
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
+from jose import JWTError
 from pydantic import BaseModel
+
 from app.auth.dependencies import get_current_user, require_role
+from app.core.security import decode_token
 from app.db.prisma_client import db
-from typing import Optional
-from fastapi import WebSocket, WebSocketDisconnect
-from typing import Dict
+from app.communication.services import (
+    ChatRepository,
+    ThreadAccessError,
+    ThreadNotFoundError,
+)
+
 
 router = APIRouter(prefix="/communication", tags=["communication"])
-
 
 
 class NoteIn(BaseModel):
@@ -17,34 +27,120 @@ class NoteIn(BaseModel):
     vehicleId: Optional[str]
     content: str
 
+
 @router.post("/notes/internal")
 async def add_internal_note(data: NoteIn, user=Depends(get_current_user)):
     require_role(["TECHNICIAN", "MANAGER", "ADMIN"])(user)
 
     await db.connect()
-    note = await db.internalnote.create(data={
-        "appointmentId": data.appointmentId,
-        "vehicleId": data.vehicleId,
-        "authorId": user.id,
-        "content": data.content
-    })
-    await db.disconnect()
+    try:
+        note = await db.internalnote.create(
+            data={
+                "appointmentId": data.appointmentId,
+                "vehicleId": data.vehicleId,
+                "authorId": user.id,
+                "content": data.content,
+            }
+        )
+    finally:
+        await db.disconnect()
+
     return {"message": "Note added", "note": note}
 
-chat_connections: Dict[str, list[WebSocket]] = {}
+
+chat_connections: Dict[str, Set[WebSocket]] = {}
+
+
+def _connection_set(thread_id: str) -> Set[WebSocket]:
+    return chat_connections.setdefault(thread_id, set())
+
+
+async def _broadcast_message(thread_id: str, payload: dict) -> None:
+    encoded = json.dumps(payload)
+    sockets = list(chat_connections.get(thread_id, set()))
+    stale: list[WebSocket] = []
+
+    for connection in sockets:
+        try:
+            await connection.send_text(encoded)
+        except Exception:  # pragma: no cover - defensive cleanup
+            stale.append(connection)
+
+    if stale:
+        remaining = chat_connections.get(thread_id)
+        if remaining is not None:
+            for connection in stale:
+                remaining.discard(connection)
+            if not remaining:
+                chat_connections.pop(thread_id, None)
+
 
 @router.websocket("/ws/chat/{thread_id}")
 async def websocket_chat(websocket: WebSocket, thread_id: str):
-    await websocket.accept()
-    if thread_id not in chat_connections:
-        chat_connections[thread_id] = []
-    chat_connections[thread_id].append(websocket)
+    token = websocket.query_params.get("token") or websocket.headers.get("Authorization")
+    if token and token.lower().startswith("bearer "):
+        token = token.split(" ", 1)[1]
+
+    if not token:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
 
     try:
-        while True:
-            data = await websocket.receive_text()
-            # Broadcast to all users in thread
-            for conn in chat_connections[thread_id]:
-                await conn.send_text(data)
-    except WebSocketDisconnect:
-        chat_connections[thread_id].remove(websocket)
+        payload = decode_token(token)
+    except JWTError:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    email = payload.get("sub")
+    if not email:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    async with ChatRepository(db) as repo:
+        user = await repo.get_user_by_email(email)
+        if not user or not getattr(user, "isActive", True):
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+        try:
+            await repo.ensure_thread_access(thread_id, user)
+        except ThreadNotFoundError:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        except ThreadAccessError:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+        await websocket.accept()
+        connections = _connection_set(thread_id)
+        connections.add(websocket)
+
+        try:
+            while True:
+                body = (await websocket.receive_text()).strip()
+                if not body:
+                    continue
+
+                message = await repo.create_message(thread_id, getattr(user, "id"), body)
+                await _broadcast_message(thread_id, message)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            connections.discard(websocket)
+            if not connections:
+                chat_connections.pop(thread_id, None)
+
+
+@router.get("/threads/{thread_id}/messages")
+async def get_thread_messages(thread_id: str, user=Depends(get_current_user)):
+    async with ChatRepository(db) as repo:
+        try:
+            await repo.ensure_thread_access(thread_id, user)
+        except ThreadNotFoundError:
+            raise HTTPException(status_code=404, detail="Thread not found")
+        except ThreadAccessError:
+            raise HTTPException(status_code=403, detail="Access to this thread is denied")
+
+        messages = await repo.list_messages(thread_id)
+
+    return messages

--- a/backend/app/communication/services.py
+++ b/backend/app/communication/services.py
@@ -1,0 +1,101 @@
+"""Chat persistence services backed by Prisma."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable, List, Sequence
+
+from app.db.prisma_client import db
+
+
+class ThreadNotFoundError(Exception):
+    """Raised when a chat thread cannot be located."""
+
+
+class ThreadAccessError(Exception):
+    """Raised when a user attempts to access a thread they are not part of."""
+
+
+def _extract(record: Any, key: str, default: Any | None = None) -> Any:
+    if isinstance(record, dict):
+        return record.get(key, default)
+    return getattr(record, key, default)
+
+
+def _normalise_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:  # pragma: no cover - defensive
+            return None
+    return None
+
+
+def serialise_message(message: Any) -> dict[str, Any]:
+    sent_at = _normalise_datetime(_extract(message, "sentAt"))
+    return {
+        "id": _extract(message, "id"),
+        "threadId": _extract(message, "threadId"),
+        "senderId": _extract(message, "senderId"),
+        "body": _extract(message, "body"),
+        "sentAt": sent_at.isoformat() if sent_at else None,
+    }
+
+
+class ChatRepository:
+    """Repository for chat threads and messages that manages DB connections."""
+
+    def __init__(self, database=db):
+        self._db = database
+        self._connected = False
+
+    async def __aenter__(self) -> "ChatRepository":
+        await self._db.connect()
+        self._connected = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._connected:
+            await self._db.disconnect()
+        self._connected = False
+
+    async def get_user_by_email(self, email: str) -> Any:
+        return await self._db.user.find_unique(where={"email": email})
+
+    async def get_thread(self, thread_id: str) -> Any:
+        return await self._db.chatthread.find_unique(where={"id": thread_id})
+
+    async def ensure_thread_access(self, thread_id: str, user: Any) -> Any:
+        thread = await self.get_thread(thread_id)
+        if not thread:
+            raise ThreadNotFoundError(thread_id)
+
+        participants: Sequence[str] = _extract(thread, "participants", []) or []
+        user_id = _extract(user, "id")
+        role = (_extract(user, "role") or "").upper()
+
+        if role not in {"ADMIN", "MANAGER"} and user_id not in set(participants):
+            raise ThreadAccessError(thread_id)
+
+        return thread
+
+    async def create_message(self, thread_id: str, sender_id: str, body: str) -> dict[str, Any]:
+        message = await self._db.chatmessage.create(
+            data={
+                "threadId": thread_id,
+                "senderId": sender_id,
+                "body": body,
+            }
+        )
+        return serialise_message(message)
+
+    async def list_messages(self, thread_id: str, limit: int = 100) -> List[dict[str, Any]]:
+        messages: Iterable[Any] = await self._db.chatmessage.find_many(
+            where={"threadId": thread_id},
+            order={"sentAt": "asc"},
+            take=limit,
+        )
+        return [serialise_message(message) for message in messages]
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1008,6 +1008,23 @@ model Vendor {
   bills     VendorBill[]
 }
 
+model ChatThread {
+  id           String        @id @default(uuid())
+  participants String[]
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  messages     ChatMessage[]
+}
+
+model ChatMessage {
+  id        String     @id @default(uuid())
+  threadId  String
+  senderId  String
+  body      String
+  sentAt    DateTime   @default(now())
+  thread    ChatThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+}
+
 model VendorInvoice {
   id        String   @id @default(uuid())
   vendor    String

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test configuration to ensure core dependencies are loaded."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Import core security early so that external dependencies like `jose`
+# are loaded before any test attempts to stub them for optional environments.
+from app.core import security  # noqa: F401

--- a/backend/tests/test_communication_chat.py
+++ b/backend/tests/test_communication_chat.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import types
+
+
+class _PrismaStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+if "prisma" in sys.modules:
+    sys.modules["prisma"].Prisma = _PrismaStub
+else:
+    sys.modules["prisma"] = types.SimpleNamespace(Prisma=_PrismaStub)
+
+from app.auth.dependencies import get_current_user
+from app.communication import routes as communication_routes
+from app.communication import services as communication_services
+
+
+@dataclass
+class FakeUser:
+    id: str
+    email: str
+    role: str = "TECHNICIAN"
+    isActive: bool = True
+
+
+@dataclass
+class FakeThread:
+    id: str
+    participants: List[str] = field(default_factory=list)
+
+
+@dataclass
+class FakeMessage:
+    id: str
+    threadId: str
+    senderId: str
+    body: str
+    sentAt: datetime
+
+
+class FakeChatThreadTable:
+    def __init__(self, records: Optional[List[FakeThread]] = None):
+        self._records: Dict[str, FakeThread] = {record.id: record for record in records or []}
+
+    async def find_unique(self, where: Dict[str, Any]):
+        return self._records.get(where.get("id"))
+
+
+class FakeChatMessageTable:
+    def __init__(self, records: Optional[List[FakeMessage]] = None):
+        self._records: List[FakeMessage] = records or []
+        self._counter = len(self._records)
+
+    async def create(self, data: Dict[str, Any]):
+        self._counter += 1
+        message = FakeMessage(
+            id=f"msg-{self._counter}",
+            threadId=data["threadId"],
+            senderId=data["senderId"],
+            body=data["body"],
+            sentAt=datetime.utcnow(),
+        )
+        self._records.append(message)
+        return message
+
+    async def find_many(self, where: Dict[str, Any], order: Optional[Dict[str, str]] = None, take: Optional[int] = None):
+        thread_id = where.get("threadId") if where else None
+        results = [record for record in self._records if not thread_id or record.threadId == thread_id]
+
+        if order and order.get("sentAt", "asc").lower() == "asc":
+            results.sort(key=lambda record: record.sentAt)
+        elif order and order.get("sentAt", "asc").lower() == "desc":
+            results.sort(key=lambda record: record.sentAt, reverse=True)
+
+        if take is not None:
+            results = results[:take]
+        return list(results)
+
+
+class FakeUserTable:
+    def __init__(self, users: Optional[List[FakeUser]] = None):
+        self._users: Dict[str, FakeUser] = {user.email: user for user in users or []}
+
+    async def find_unique(self, where: Dict[str, Any]):
+        lookup = where.get("email")
+        return self._users.get(lookup)
+
+
+class FakeDB:
+    def __init__(self, *, users: List[FakeUser], threads: List[FakeThread], messages: Optional[List[FakeMessage]] = None):
+        self.connected = False
+        self.user = FakeUserTable(users)
+        self.chatthread = FakeChatThreadTable(threads)
+        self.chatmessage = FakeChatMessageTable(messages)
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.connected = False
+
+
+@pytest.fixture
+def patch_chat_db(monkeypatch):
+    def _patch(fake_db: FakeDB):
+        monkeypatch.setattr(communication_routes, "db", fake_db)
+        monkeypatch.setattr(communication_services, "db", fake_db)
+
+    return _patch
+
+
+def create_app(current_user: FakeUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(communication_routes.router)
+    app.dependency_overrides[get_current_user] = lambda: current_user
+    return app
+
+
+def test_chat_repository_persists_messages(patch_chat_db):
+    user = FakeUser(id="user-1", email="tech@example.com")
+    thread = FakeThread(id="thread-1", participants=[user.id])
+    fake_db = FakeDB(users=[user], threads=[thread])
+    patch_chat_db(fake_db)
+
+    async def _store_message():
+        async with communication_services.ChatRepository(fake_db) as repo:
+            return await repo.create_message(thread.id, user.id, "Hello")
+
+    stored = asyncio.run(_store_message())
+
+    assert stored["body"] == "Hello"
+    assert stored["senderId"] == user.id
+    assert stored["threadId"] == thread.id
+    assert "T" in stored["sentAt"]
+    assert not fake_db.connected
+
+
+def test_message_history_returns_sorted_messages(patch_chat_db):
+    user = FakeUser(id="user-1", email="tech@example.com")
+    thread = FakeThread(id="thread-1", participants=[user.id])
+    earlier = FakeMessage(
+        id="msg-1",
+        threadId=thread.id,
+        senderId=user.id,
+        body="first",
+        sentAt=datetime.utcnow() - timedelta(minutes=5),
+    )
+    later = FakeMessage(
+        id="msg-2",
+        threadId=thread.id,
+        senderId=user.id,
+        body="second",
+        sentAt=datetime.utcnow(),
+    )
+
+    fake_db = FakeDB(users=[user], threads=[thread], messages=[later, earlier])
+    patch_chat_db(fake_db)
+
+    app = create_app(user)
+    client = TestClient(app)
+
+    response = client.get(f"/communication/threads/{thread.id}/messages")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [message["body"] for message in payload] == ["first", "second"]
+
+
+def test_message_history_enforces_participation(patch_chat_db):
+    participant = FakeUser(id="user-1", email="tech@example.com")
+    outsider = FakeUser(id="user-2", email="viewer@example.com")
+    thread = FakeThread(id="thread-1", participants=[participant.id])
+
+    fake_db = FakeDB(users=[participant, outsider], threads=[thread])
+    patch_chat_db(fake_db)
+
+    app = create_app(outsider)
+    client = TestClient(app)
+
+    response = client.get(f"/communication/threads/{thread.id}/messages")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Access to this thread is denied"
+
+
+def test_message_history_allows_admin_override(patch_chat_db):
+    participant = FakeUser(id="user-1", email="tech@example.com")
+    admin = FakeUser(id="admin", email="admin@example.com", role="ADMIN")
+    thread = FakeThread(id="thread-1", participants=[participant.id])
+
+    fake_db = FakeDB(users=[participant, admin], threads=[thread])
+    patch_chat_db(fake_db)
+
+    app = create_app(admin)
+    client = TestClient(app)
+
+    response = client.get(f"/communication/threads/{thread.id}/messages")
+
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- add Prisma models for chat threads and messages and supporting repository helpers
- secure the chat websocket, persist inbound messages, and expose a thread history endpoint
- cover chat persistence and access control with dedicated unit tests and shared fixtures

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e1e623c01c832cae9b3b5547155750