### PR TITLE
Expand admin metrics and add audit maintenance endpoints

### DIFF
--- a/backend/app/admin/routes.py
+++ b/backend/app/admin/routes.py
@@ -1,38 +1,105 @@
-from app.auth.dependencies import get_current_user, require_role
-from app.db.prisma_client import db
-from fastapi import Depends
+from datetime import datetime, timedelta
+from typing import Any
+
 from fastapi import APIRouter
+from fastapi import Depends
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, EmailStr
-from datetime import datetime, timedelta
+from pydantic import BaseModel, Field
+
+from app.auth.dependencies import get_current_user, require_role
+from app.core.notifier import send_email
+from app.db.prisma_client import db
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 # Financial Dashboard and Reporting Endpoints 
 @router.get("/admin/metrics")
-async def financial_dashboard(user = Depends(get_current_user)):
+async def financial_dashboard(user: Any = Depends(get_current_user)):
+    """Return headline metrics for the admin dashboard."""
+
     require_role(["ADMIN", "MANAGER"])(user)
+
     await db.connect()
 
-    invoices = await db.invoice.aggregate(_sum={"total": True})
-    payments = await db.payment.aggregate(_sum={"amount": True})
-    total_rev = invoices._sum.total or 0
-    total_paid = payments._sum.amount or 0
+    try:
+        invoice_agg = await db.invoice.aggregate(
+            _sum={"total": True},
+            _count={"_all": True},
+        )
+        payment_agg = await db.payment.aggregate(_sum={"amount": True})
+        user_agg = await db.user.aggregate(_count={"_all": True})
+        technician_agg = await db.user.aggregate(
+            where={"role": "TECHNICIAN"},
+            _count={"_all": True},
+        )
+        vehicle_agg = await db.vehicle.aggregate(_count={"_all": True})
+        customer_agg = await db.customer.aggregate(_count={"_all": True})
+        job_agg = await db.job.aggregate(_count={"_all": True})
+        completed_job_agg = await db.job.aggregate(
+            where={"status": "COMPLETED"},
+            _count={"_all": True},
+        )
+        outstanding_invoice_agg = await db.invoice.aggregate(
+            where={"status": {"in": ["UNPAID", "PARTIALLY_PAID"]}},
+            _count={"_all": True},
+        )
+        warranty_agg = await db.warrantyclaim.aggregate(_count={"_all": True})
+        open_warranty_agg = await db.warrantyclaim.aggregate(
+            where={"status": {"notIn": ["APPROVED", "REJECTED"]}},
+            _count={"_all": True},
+        )
+    finally:
+        await db.disconnect()
+
+    def _count(agg: Any) -> int:
+        count_block = getattr(agg, "_count", None)
+        if not count_block:
+            return 0
+        value = getattr(count_block, "_all", 0)
+        return value or 0
+
+    def _sum(agg: Any, field: str) -> float:
+        sum_block = getattr(agg, "_sum", None)
+        if not sum_block:
+            return 0.0
+        value = getattr(sum_block, field, 0.0)
+        return float(value or 0.0)
+
+    total_revenue = _sum(invoice_agg, "total")
+    total_collected = _sum(payment_agg, "amount")
 
     # Placeholder COGS logic; later link to part cost per order
-    cogs = round(total_rev * 0.4, 2)
-    gross_margin = round(total_rev - cogs, 2)
-    margin_percent = round((gross_margin / total_rev * 100), 2) if total_rev else 0
-
-    await db.disconnect()
+    cogs = round(total_revenue * 0.4, 2)
+    gross_margin = round(total_revenue - cogs, 2)
+    margin_percent = round((gross_margin / total_revenue * 100), 2) if total_revenue else 0.0
 
     return {
-        "total_revenue": total_rev,
-        "total_collected": total_paid,
-        "cogs": cogs,
-        "gross_margin": gross_margin,
-        "margin_percent": margin_percent
+        "financial": {
+            "total_revenue": total_revenue,
+            "total_collected": total_collected,
+            "cogs": cogs,
+            "gross_margin": gross_margin,
+            "margin_percent": margin_percent,
+        },
+        "counts": {
+            "users": _count(user_agg),
+            "technicians": _count(technician_agg),
+            "customers": _count(customer_agg),
+            "vehicles": _count(vehicle_agg),
+            "jobs": {
+                "total": _count(job_agg),
+                "completed": _count(completed_job_agg),
+            },
+            "invoices": {
+                "total": _count(invoice_agg),
+                "outstanding": _count(outstanding_invoice_agg),
+            },
+            "warranty_claims": {
+                "total": _count(warranty_agg),
+                "open": _count(open_warranty_agg),
+            },
+        },
     }
     
 # Technician Performance Summary Endpoint
@@ -125,20 +192,86 @@ async def update_claim_status(claim_id: str, data: ClaimStatusUpdate, user=Depen
         raise HTTPException(400, "Invalid status")
 
     await db.connect()
-    claim = await db.warrantyclaim.update(
-        where={"id": claim_id},
-        data={"status": data.status}
-    )
-    await db.disconnect()
+    try:
+        claim = await db.warrantyclaim.update(
+            where={"id": claim_id},
+            data={"status": data.status},
+            include={"customer": True, "workOrder": True},
+        )
+    finally:
+        await db.disconnect()
+
+    if getattr(claim, "customer", None) and getattr(claim.customer, "email", None):
+        await send_email(
+            claim.customer.email,
+            "Warranty Claim Status Update",
+            f"Your claim for Work Order #{getattr(claim, 'workOrderId', '')} has been {data.status.lower()}.",
+        )
+
     return {"message": f"Claim {data.status.lower()}", "claim": claim}
 
 
-if claim.customer.email:
-    await send_email(
-        to=claim.customer.email,
-        subject="Warranty Claim Status Update",
-        body=f"Your claim for Work Order #{claim.workOrderId} has been {data.status.lower()}."
-    )
+class AuditLogPurgeRequest(BaseModel):
+    older_than_days: int = Field(365, gt=0, le=1825)
+
+
+@router.get("/admin/audit/logs")
+async def list_audit_logs(
+    page: int = 1,
+    page_size: int = 50,
+    user: Any = Depends(get_current_user),
+):
+    require_role(["ADMIN"])(user)
+
+    page = max(page, 1)
+    page_size = min(max(page_size, 1), 200)
+
+    await db.connect()
+    try:
+        total_agg = await db.auditlog.aggregate(_count={"_all": True})
+        logs = await db.auditlog.find_many(
+            order={"timestamp": "desc"},
+            skip=(page - 1) * page_size,
+            take=page_size,
+        )
+    finally:
+        await db.disconnect()
+
+    total = 0
+    if getattr(total_agg, "_count", None):
+        total = getattr(total_agg._count, "_all", 0) or 0
+
+    return {
+        "items": logs,
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+        },
+    }
+
+
+@router.post("/admin/audit/purge")
+async def purge_audit_logs(
+    payload: AuditLogPurgeRequest,
+    user: Any = Depends(get_current_user),
+):
+    require_role(["ADMIN"])(user)
+
+    cutoff = datetime.utcnow() - timedelta(days=payload.older_than_days)
+
+    await db.connect()
+    try:
+        deleted = await db.auditlog.delete_many(where={"timestamp": {"lt": cutoff}})
+    finally:
+        await db.disconnect()
+
+    deleted_count = getattr(deleted, "count", None)
+    if deleted_count is None:
+        # Prisma returns a dictionary-like object in older versions
+        deleted_count = deleted.get("count", 0) if isinstance(deleted, dict) else 0
+
+    return {"deleted": deleted_count, "cutoff": cutoff.isoformat()}
 
 # Exports Warranty Claims as CSVF
 @router.get("/warranty/export.csv")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,10 +1,38 @@
 """Shared test configuration to ensure core dependencies are loaded."""
 
 import sys
+import types
 from pathlib import Path
+
+if "jose" not in sys.modules:
+    fake_jwt = types.SimpleNamespace(
+        encode=lambda *args, **kwargs: "token",
+        decode=lambda *args, **kwargs: {},
+    )
+    fake_exceptions = types.SimpleNamespace(ExpiredSignatureError=Exception)
+    fake_jose = types.SimpleNamespace(JWTError=Exception, jwt=fake_jwt, exceptions=fake_exceptions)
+    sys.modules["jose"] = fake_jose
+    sys.modules["jose.jwt"] = fake_jwt
+    sys.modules["jose.exceptions"] = fake_exceptions
+
+if "passlib" not in sys.modules:
+    class _FakeCryptContext:
+        def hash(self, value: str) -> str:  # pragma: no cover - deterministic stub
+            return f"hashed:{value}"
+
+        def verify(self, plain: str, hashed: str) -> bool:  # pragma: no cover
+            return hashed.endswith(plain)
+
+    fake_passlib = types.ModuleType("passlib")
+    fake_passlib_context = types.SimpleNamespace(CryptContext=lambda **_kwargs: _FakeCryptContext())
+    sys.modules["passlib"] = fake_passlib
+    sys.modules["passlib.context"] = fake_passlib_context
+
+if "dotenv" not in sys.modules:
+    sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=lambda *args, **kwargs: None)
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-# Import core security early so that external dependencies like `jose`
-# are loaded before any test attempts to stub them for optional environments.
+# Import core security early so that optional dependencies like `jose`
+# are loaded (or stubbed) before any tests interact with them.
 from app.core import security  # noqa: F401

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.admin import routes  # noqa: E402
+
+
+async def _noop(*_: Any, **__: Any) -> None:
+    return None
+
+
+class _AsyncIterator:
+    def __init__(self, results: Iterable[Any]) -> None:
+        self._iterator = iter(results)
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D401 - helper
+        return next(self._iterator)
+
+
+def _constant(result: Any):
+    async def _inner(*args: Any, **kwargs: Any) -> Any:
+        return result
+
+    return _inner
+
+
+@pytest.mark.asyncio
+async def test_financial_dashboard_shapes_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(routes.db, "connect", _noop)
+    monkeypatch.setattr(routes.db, "disconnect", _noop)
+
+    invoice_results = _AsyncIterator([
+        SimpleNamespace(
+            _sum=SimpleNamespace(total=1200.0),
+            _count=SimpleNamespace(_all=8),
+        ),
+        SimpleNamespace(_count=SimpleNamespace(_all=3)),
+    ])
+    monkeypatch.setattr(routes.db, "invoice", SimpleNamespace(aggregate=invoice_results))
+
+    monkeypatch.setattr(
+        routes.db,
+        "payment",
+        SimpleNamespace(aggregate=_constant(SimpleNamespace(_sum=SimpleNamespace(amount=950.0)))),
+    )
+
+    user_results = _AsyncIterator([
+        SimpleNamespace(_count=SimpleNamespace(_all=15)),
+        SimpleNamespace(_count=SimpleNamespace(_all=6)),
+    ])
+    monkeypatch.setattr(routes.db, "user", SimpleNamespace(aggregate=user_results))
+
+    monkeypatch.setattr(
+        routes.db,
+        "vehicle",
+        SimpleNamespace(aggregate=_constant(SimpleNamespace(_count=SimpleNamespace(_all=42)))),
+    )
+    monkeypatch.setattr(
+        routes.db,
+        "customer",
+        SimpleNamespace(aggregate=_constant(SimpleNamespace(_count=SimpleNamespace(_all=27)))),
+    )
+
+    job_results = _AsyncIterator([
+        SimpleNamespace(_count=SimpleNamespace(_all=18)),
+        SimpleNamespace(_count=SimpleNamespace(_all=11)),
+    ])
+    monkeypatch.setattr(routes.db, "job", SimpleNamespace(aggregate=job_results))
+
+    warranty_results = _AsyncIterator([
+        SimpleNamespace(_count=SimpleNamespace(_all=5)),
+        SimpleNamespace(_count=SimpleNamespace(_all=2)),
+    ])
+    monkeypatch.setattr(routes.db, "warrantyclaim", SimpleNamespace(aggregate=warranty_results))
+
+    result = await routes.financial_dashboard(SimpleNamespace(role="ADMIN"))
+
+    assert result["financial"]["total_revenue"] == 1200.0
+    assert result["financial"]["total_collected"] == 950.0
+    assert result["counts"]["users"] == 15
+    assert result["counts"]["technicians"] == 6
+    assert result["counts"]["vehicles"] == 42
+    assert result["counts"]["jobs"]["total"] == 18
+    assert result["counts"]["jobs"]["completed"] == 11
+    assert result["counts"]["invoices"]["total"] == 8
+    assert result["counts"]["invoices"]["outstanding"] == 3
+    assert result["counts"]["warranty_claims"]["total"] == 5
+    assert result["counts"]["warranty_claims"]["open"] == 2
+
+
+class _AuditAccessor:
+    def __init__(self) -> None:
+        self.find_calls: list[dict[str, Any]] = []
+
+    async def aggregate(self, *_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(_count=SimpleNamespace(_all=10))
+
+    async def find_many(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.find_calls.append(kwargs)
+        return [{"id": "1", "action": "LOGIN"}]
+
+    async def delete_many(self, **_kwargs: Any) -> Any:
+        return SimpleNamespace(count=4)
+
+
+@pytest.mark.asyncio
+async def test_list_audit_logs_returns_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    accessor = _AuditAccessor()
+    monkeypatch.setattr(routes.db, "connect", _noop)
+    monkeypatch.setattr(routes.db, "disconnect", _noop)
+    monkeypatch.setattr(routes.db, "auditlog", accessor)
+
+    response = await routes.list_audit_logs(page=2, page_size=25, user=SimpleNamespace(role="ADMIN"))
+
+    assert response["pagination"] == {"page": 2, "page_size": 25, "total": 10}
+    assert response["items"] == [{"id": "1", "action": "LOGIN"}]
+    assert accessor.find_calls == [
+        {"order": {"timestamp": "desc"}, "skip": 25, "take": 25}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_purge_audit_logs_reports_deleted(monkeypatch: pytest.MonkeyPatch) -> None:
+    accessor = _AuditAccessor()
+    monkeypatch.setattr(routes.db, "connect", _noop)
+    monkeypatch.setattr(routes.db, "disconnect", _noop)
+    monkeypatch.setattr(routes.db, "auditlog", accessor)
+
+    payload = routes.AuditLogPurgeRequest(older_than_days=30)
+    result = await routes.purge_audit_logs(payload, user=SimpleNamespace(role="ADMIN"))
+
+    assert result["deleted"] == 4
+    assert "cutoff" in result


### PR DESCRIPTION
## Summary
- extend the `/admin/metrics` dashboard endpoint to aggregate key counts alongside revenue totals and fix the warranty email notification flow
- add admin audit log pagination and purge endpoints backed by Prisma aggregations
- introduce tests that validate the dashboard payload structure while stubbing optional dependencies required for the suite

## Testing
- pytest *(fails: missing optional FastAPI/httpx dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ec276ac0832c895d45c1f227a62f