### PR TITLE
Improve websocket broadcast resiliency

### DIFF
--- a/backend/app/core/broadcast.py
+++ b/backend/app/core/broadcast.py
@@ -1,21 +1,110 @@
-# backend/app/core/broadcast.py
-# This module handles broadcasting messages to WebSocket connections.
-# It is used to send real-time updates to connected clients.
+"""Utilities for broadcasting messages to WebSocket connections."""
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from ws.routes import active_connections
-from ws.routes import tech_connections
+from __future__ import annotations
+
 import json
+import logging
+from typing import Any, Dict, Tuple
 
-router = APIRouter(prefix="/broadcast", tags=["broadcast"])
+try:  # pragma: no cover - optional dependency for typing
+    from starlette.websockets import WebSocket  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - starlette not installed in tests
+    WebSocket = Any  # type: ignore[misc, assignment]
+
+logger = logging.getLogger(__name__)
+
+_job_connections: set[WebSocket] = set()
+_technician_connections: Dict[str, WebSocket] = {}
 
 
-async def broadcast_job_update(job_data: dict):
+def register_job_connection(websocket: WebSocket) -> None:
+    """Register a job broadcast WebSocket connection."""
+
+    _job_connections.add(websocket)
+
+
+def unregister_job_connection(websocket: WebSocket) -> None:
+    """Remove a job broadcast WebSocket connection if present."""
+
+    _job_connections.discard(websocket)
+
+
+def register_technician_connection(tech_id: str, websocket: WebSocket) -> None:
+    """Register the WebSocket associated with a technician."""
+
+    _technician_connections[tech_id] = websocket
+
+
+def unregister_technician_connection(tech_id: str) -> None:
+    """Unregister the WebSocket associated with a technician."""
+
+    _technician_connections.pop(tech_id, None)
+
+
+def iter_job_connections() -> Tuple[WebSocket, ...]:
+    """Return a snapshot of active job broadcast connections."""
+
+    return tuple(_job_connections)
+
+
+def iter_connected_technicians() -> Tuple[str, ...]:
+    """Return a snapshot of connected technician identifiers."""
+
+    return tuple(_technician_connections.keys())
+
+
+def _state_is_connected(state: object) -> bool:
+    """Return ``True`` if a websocket state represents an active connection."""
+
+    if state is None:
+        return True
+    name = getattr(state, "name", state)
+    return str(name).upper() == "CONNECTED"
+
+
+def _should_prune(websocket: WebSocket) -> bool:
+    """Check whether a websocket is no longer connected."""
+
+    client_state = getattr(websocket, "client_state", None)
+    application_state = getattr(websocket, "application_state", None)
+    return not (_state_is_connected(client_state) and _state_is_connected(application_state))
+
+
+async def _safe_send(websocket: WebSocket, payload: str) -> bool:
+    """Attempt to send data and return ``True`` if successful."""
+
+    if _should_prune(websocket):
+        return False
+
+    try:
+        await websocket.send_text(payload)
+        return True
+    except Exception:  # pragma: no cover - defensive logging
+        logger.warning("Failed to send message to websocket; pruning connection.", exc_info=True)
+        return False
+
+
+async def broadcast_job_update(job_data: dict) -> None:
+    """Broadcast job data to all connected WebSocket clients."""
+
     message = json.dumps(job_data)
-    for ws in active_connections:
-        await ws.send_text(message)
+    stale: list[WebSocket] = []
 
-async def notify_technician(tech_id: str, data: dict):
-    if tech_id in tech_connections:
-        await tech_connections[tech_id].send_text(json.dumps(data))
+    for websocket in iter_job_connections():
+        if not await _safe_send(websocket, message):
+            stale.append(websocket)
+
+    for websocket in stale:
+        unregister_job_connection(websocket)
+
+
+async def notify_technician(tech_id: str, data: dict) -> None:
+    """Send a message to a specific technician if connected."""
+
+    websocket = _technician_connections.get(tech_id)
+    if websocket is None:
+        return
+
+    message = json.dumps(data)
+    if not await _safe_send(websocket, message):
+        unregister_technician_connection(tech_id)

--- a/backend/app/monitor/routes.py
+++ b/backend/app/monitor/routes.py
@@ -1,11 +1,14 @@
-# backend/app/monitor/routes.py
-# This file contains monitoring routes for tracking system health and WebSocket connections.
+"""Routes for monitoring websocket connections."""
+
 from fastapi import APIRouter, Depends
+
 from app.auth.dependencies import get_current_user, require_role
+from app.core.broadcast import iter_connected_technicians
 
-APIRouter = APIRouter(prefix="/monitor", tags=["monitor"])
+router = APIRouter(prefix="/monitor", tags=["monitor"])
 
-@router.get("/monitor/ws-connections")
-async def list_ws_connections(user = Depends(get_current_user)):
+
+@router.get("/ws-connections")
+async def list_ws_connections(user=Depends(get_current_user)):
     require_role(["ADMIN"])(user)
-    return {"connected_technicians": list(connected_techs)}
+    return {"connected_technicians": list(iter_connected_technicians())}

--- a/backend/tests/test_broadcast.py
+++ b/backend/tests/test_broadcast.py
@@ -1,0 +1,82 @@
+"""Tests for websocket broadcast helper utilities."""
+
+import asyncio
+import json
+
+import pytest
+
+from app.core import broadcast
+
+
+class DummyWebSocket:
+    """Minimal async websocket stub for exercising broadcast helpers."""
+
+    def __init__(self, *, should_fail: bool = False):
+        self.should_fail = should_fail
+        self.messages: list[str] = []
+        self.client_state = "CONNECTED"
+        self.application_state = "CONNECTED"
+        self._send_attempts = 0
+
+    async def send_text(self, data: str) -> None:  # pragma: no cover - exercised via tests
+        self._send_attempts += 1
+        if self.should_fail:
+            self.client_state = "DISCONNECTED"
+            self.application_state = "DISCONNECTED"
+            raise RuntimeError("connection closed")
+        self.messages.append(data)
+
+
+def test_broadcast_job_update_prunes_closed_connections(caplog):
+    async def runner() -> None:
+        ws_success_one = DummyWebSocket()
+        ws_failing = DummyWebSocket(should_fail=True)
+        ws_success_two = DummyWebSocket()
+
+        broadcast.register_job_connection(ws_success_one)
+        broadcast.register_job_connection(ws_failing)
+        broadcast.register_job_connection(ws_success_two)
+
+        with caplog.at_level("WARNING"):
+            await broadcast.broadcast_job_update({"job": 123})
+
+        # Messages delivered to healthy sockets.
+        payload = json.dumps({"job": 123})
+        assert ws_success_one.messages == [payload]
+        assert ws_success_two.messages == [payload]
+
+        # Failing socket removed from the registry and logged.
+        assert ws_failing not in broadcast.iter_job_connections()
+        assert any("Failed to send message" in rec.message for rec in caplog.records)
+
+        # Subsequent broadcasts continue reaching remaining clients.
+        await broadcast.broadcast_job_update({"job": 456})
+        second_payload = json.dumps({"job": 456})
+        assert ws_success_one.messages[-1] == second_payload
+        assert ws_success_two.messages[-1] == second_payload
+
+        broadcast.unregister_job_connection(ws_success_one)
+        broadcast.unregister_job_connection(ws_success_two)
+
+    asyncio.run(runner())
+
+
+def test_notify_technician_removes_failed_connection():
+    async def runner() -> None:
+        ws_ok = DummyWebSocket()
+        ws_fail = DummyWebSocket(should_fail=True)
+
+        broadcast.register_technician_connection("ok", ws_ok)
+        broadcast.register_technician_connection("fail", ws_fail)
+
+        await broadcast.notify_technician("fail", {"note": "update"})
+
+        # Connection removed after the failed send attempt.
+        assert "fail" not in broadcast.iter_connected_technicians()
+
+        await broadcast.notify_technician("ok", {"note": "status"})
+        assert ws_ok.messages == [json.dumps({"note": "status"})]
+
+        broadcast.unregister_technician_connection("ok")
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- guard websocket broadcasts against closed connections, logging failures and pruning stale sockets
- expose registration helpers from the broadcast module and update websocket/monitor routes to consume them
- add tests covering disconnection scenarios to ensure broadcasts continue for remaining clients

## Testing
- pytest tests/test_broadcast.py

------
https://chatgpt.com/codex/tasks/task_e_68e2078d70c0832c90ec132644f1853b