### PR TITLE
Refactor settings to Pydantic configuration with validation

### DIFF
--- a/backend/app/alerts/routes.py
+++ b/backend/app/alerts/routes.py
@@ -58,7 +58,7 @@ async def bay_overload_alert(user = Depends(get_current_user)):
     alerts = []
     for bay, days in usage.items():
         for date, count in days.items():
-            if count > settings.MAX_BAY_JOBS_PER_DAY:
+            if count > settings.thresholds.max_bay_jobs_per_day:
                 alerts.append({"bay": bay, "date": date, "job_count": count})
 
     if alerts:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,26 +1,155 @@
-# backend/app/core/config.py
-## This file contains the application settings and configuration.
-# It loads environment variables from a .env file and provides default values for various settings.
-import os
+"""Central application configuration powered by Pydantic settings."""
+
+from __future__ import annotations
+
+from typing import List
+
 from dotenv import load_dotenv
-from os import getenv
+from pydantic import BaseSettings, Field, root_validator, validator
 
 load_dotenv()
 
-class Settings:
-    DATABASE_URL: str = os.getenv("DATABASE_URL")
-    SECRET_KEY: str = os.getenv("SECRET_KEY", "supersecret")
-    ALGORITHM: str = os.getenv("ALGORITHM", "HS256")
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30))
-    RESET_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("RESET_TOKEN_EXPIRE_MINUTES", 15))
-    STRIPE_SECRET_KEY: str = os.getenv("STRIPE_SECRET_KEY", "")
-    ENV: str = os.getenv("ENV", "development")
-    INVOICE_MARGIN_ALERT_THRESHOLD = 25.0  # percent
-    SUBSTITUTION_REORDER_THRESHOLD = 3
-    UNIT_COST_ALERT_THRESHOLD = 1.15  # 15% above last known cost
-    MAX_BAY_JOBS_PER_DAY = 12
+
+class SMTPSettings(BaseSettings):
+    """Outgoing mail server configuration."""
+
+    host: str | None = Field(default=None, env="SMTP_HOST")
+    port: int = Field(default=587, env="SMTP_PORT")
+    username: str | None = Field(default=None, env="SMTP_USER")
+    password: str | None = Field(default=None, env="SMTP_PASS")
+    from_address: str = Field(default="noreply@repairshop.com", env="EMAIL_FROM")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        allow_mutation = True
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.host and self.username and self.password)
 
 
+class QuickBooksSettings(BaseSettings):
+    """QuickBooks integration credentials."""
+
+    client_id: str | None = Field(default=None, env="QUICKBOOKS_CLIENT_ID")
+    client_secret: str | None = Field(default=None, env="QUICKBOOKS_CLIENT_SECRET")
+    redirect_uri: str | None = Field(default=None, env="QUICKBOOKS_REDIRECT_URI")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        allow_mutation = True
+
+
+class GoogleOAuthSettings(BaseSettings):
+    """Google OAuth client configuration."""
+
+    client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
+    client_secret: str | None = Field(default=None, env="GOOGLE_CLIENT_SECRET")
+    redirect_uri: str | None = Field(default=None, env="GOOGLE_REDIRECT_URI")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        allow_mutation = True
+
+
+class ThresholdSettings(BaseSettings):
+    """Aggregated alert thresholds used across the application."""
+
+    invoice_margin_alert_percent: float = Field(25.0, env="INVOICE_MARGIN_ALERT_THRESHOLD")
+    substitution_reorder: int = Field(3, env="SUBSTITUTION_REORDER_THRESHOLD")
+    unit_cost_multiplier: float = Field(1.15, env="UNIT_COST_ALERT_THRESHOLD")
+    max_bay_jobs_per_day: int = Field(12, env="MAX_BAY_JOBS_PER_DAY")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        allow_mutation = True
+
+
+class TwilioSettings(BaseSettings):
+    """Twilio credentials for SMS notifications."""
+
+    account_sid: str | None = Field(default=None, env="TWILIO_ACCOUNT_SID")
+    auth_token: str | None = Field(default=None, env="TWILIO_AUTH_TOKEN")
+    from_number: str | None = Field(default=None, env="TWILIO_FROM_NUMBER")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        allow_mutation = True
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.account_sid and self.auth_token and self.from_number)
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from the environment with validation."""
+
+    database_url: str | None = Field(default=None, env="DATABASE_URL")
+    secret_key: str = Field(default="supersecret", env="SECRET_KEY")
+    algorithm: str = Field(default="HS256", env="ALGORITHM")
+    access_token_expire_minutes: int = Field(default=30, env="ACCESS_TOKEN_EXPIRE_MINUTES")
+    reset_token_expire_minutes: int = Field(default=15, env="RESET_TOKEN_EXPIRE_MINUTES")
+    stripe_secret_key: str | None = Field(default=None, env="STRIPE_SECRET_KEY")
+    env: str = Field(default="development", env="ENV")
+
+    smtp: SMTPSettings = Field(default_factory=SMTPSettings)
+    quickbooks: QuickBooksSettings = Field(default_factory=QuickBooksSettings)
+    google: GoogleOAuthSettings = Field(default_factory=GoogleOAuthSettings)
+    twilio: TwilioSettings = Field(default_factory=TwilioSettings)
+    thresholds: ThresholdSettings = Field(default_factory=ThresholdSettings)
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+
+    @validator("env", pre=True)
+    def _normalise_env(cls, value: str | None) -> str:
+        if not value:
+            return "development"
+        return value.lower()
+
+    @root_validator()
+    def _validate_production_requirements(cls, values: dict[str, object]) -> dict[str, object]:
+        env = values.get("env", "development")
+        if env == "production":
+            missing: List[str] = []
+
+            def _missing(field: str, env_name: str, *, disallow_default: str | None = None) -> None:
+                val = values.get(field)
+                if not val or (disallow_default and val == disallow_default):
+                    missing.append(env_name)
+
+            _missing("database_url", "DATABASE_URL")
+            _missing("secret_key", "SECRET_KEY", disallow_default="supersecret")
+            _missing("stripe_secret_key", "STRIPE_SECRET_KEY")
+
+            smtp: SMTPSettings | None = values.get("smtp")  # type: ignore[assignment]
+            if not smtp or not smtp.host:
+                missing.append("SMTP_HOST")
+            if not smtp or not smtp.username:
+                missing.append("SMTP_USER")
+            if not smtp or not smtp.password:
+                missing.append("SMTP_PASS")
+
+            if missing:
+                required = ", ".join(sorted(set(missing)))
+                raise ValueError(
+                    "Missing required environment variables for production: " + required
+                )
+
+        return values
 
 
 settings = Settings()
+

--- a/backend/app/integrations/routes.py
+++ b/backend/app/integrations/routes.py
@@ -3,20 +3,19 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from app.auth.dependencies import get_current_user, require_role
+from app.core.config import settings
 from app.db.prisma_client import db
 from fastapi import Request
 from google_auth_oauthlib.flow import Flow
 
-GOOGLE_CLIENT_ID = "your-client-id"
-GOOGLE_CLIENT_SECRET = "your-client-secret"
-
 @router.get("/auth/calendar/google/start")
 async def google_auth_start():
+    google_settings = settings.google
     flow = Flow.from_client_config(
         {
             "web": {
-                "client_id": GOOGLE_CLIENT_ID,
-                "client_secret": GOOGLE_CLIENT_SECRET,
+                "client_id": google_settings.client_id,
+                "client_secret": google_settings.client_secret,
                 "redirect_uris": ["http://localhost:8000/auth/calendar/google/callback"],
                 "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                 "token_uri": "https://oauth2.googleapis.com/token",
@@ -30,6 +29,7 @@ async def google_auth_start():
 
 @router.get("/auth/calendar/google/callback")
 async def google_auth_callback(request: Request):
+    google_settings = settings.google
     flow = Flow.from_client_config(
         {...}, scopes=["https://www.googleapis.com/auth/calendar"]
     )
@@ -58,14 +58,19 @@ def sync_to_google(user_token, appointment):
 from twilio.rest import Client
 
 def send_sms(customer_id: str, message: str):
-    client = Client(account_sid, auth_token)
+    twilio_settings = settings.twilio
+    client = Client(twilio_settings.account_sid, twilio_settings.auth_token)
 
     db = Prisma()
     await db.connect()
     customer = await db.customer.find_unique(where={"id": customer_id})
     if customer.smsOptIn:
         try:
-            client.messages.create(to=customer.phone, from_="YourNumber", body=message)
+            client.messages.create(
+                to=customer.phone,
+                from_=twilio_settings.from_number,
+                body=message,
+            )
             status = "SENT"
         except:
             status = "FAILED"

--- a/backend/app/inventory/routes.py
+++ b/backend/app/inventory/routes.py
@@ -2,6 +2,7 @@
 # This file contains inventory management routes for handling parts, stock transfers, and purchase orders.
 
 from fastapi import APIRouter, Depends, HTTPException
+from app.core.config import settings
 from app.core.notifier import send_email
 from fastapi import UploadFile, File
 import uuid, os
@@ -621,7 +622,7 @@ async def auto_reorder_from_substitution(user = Depends(get_current_user)):
 
     reordered = []
     for sku, c in count.items():
-        if c >= SUBSTITUTION_REORDER_THRESHOLD:
+        if c >= settings.thresholds.substitution_reorder:
             await db.purchaseorder.create({
                 "sku": sku,
                 "quantity": 10,  # configurable default
@@ -678,7 +679,7 @@ async def restock_item(
         order={"createdAt": "desc"}
     )
 
-    if last and unit_cost > last.unitCost * UNIT_COST_ALERT_THRESHOLD:
+    if last and unit_cost > last.unitCost * settings.thresholds.unit_cost_multiplier:
         await notify_user(
             email="procurement@repairshop.com",
             subject="⚠️ High Unit Cost Alert",

--- a/backend/app/jobs/routes.py
+++ b/backend/app/jobs/routes.py
@@ -3,6 +3,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from app.auth.dependencies import get_current_user, require_role
+from app.core.config import settings
 from app.db.prisma_client import db
 from datetime import datetime
 
@@ -294,7 +295,7 @@ async def create_job(data: JobCreate, user = Depends(get_current_user)):
     )
     await db.disconnect()
 
-    if len(jobs_today) >= MAX_BAY_JOBS_PER_DAY:
+    if len(jobs_today) >= settings.thresholds.max_bay_jobs_per_day:
         raise HTTPException(status_code=400, detail="Bay is at capacity for today")
 
     # Proceed with job creation

--- a/backend/tests/test_alerts_routes.py
+++ b/backend/tests/test_alerts_routes.py
@@ -143,7 +143,7 @@ def test_bay_overload_alert_uses_settings_threshold(fake_db: FakeDB, monkeypatch
         SimpleNamespace(bayId="BAY-1", createdAt=datetime(2024, 1, 1, 10, 0, 0)),
     ]
 
-    monkeypatch.setattr(routes.settings, "MAX_BAY_JOBS_PER_DAY", 2)
+    monkeypatch.setattr(routes.settings.thresholds, "max_bay_jobs_per_day", 2)
 
     notifications: List[tuple[tuple[Any, ...], dict[str, Any]]] = []
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import Settings
+
+
+def test_production_missing_required_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENV", "production")
+    for key in [
+        "DATABASE_URL",
+        "SECRET_KEY",
+        "STRIPE_SECRET_KEY",
+        "SMTP_HOST",
+        "SMTP_USER",
+        "SMTP_PASS",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        Settings()
+
+    message = str(excinfo.value)
+    for expected in [
+        "DATABASE_URL",
+        "SECRET_KEY",
+        "STRIPE_SECRET_KEY",
+        "SMTP_HOST",
+        "SMTP_USER",
+        "SMTP_PASS",
+    ]:
+        assert expected in message
+
+
+def test_production_allows_when_env_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENV", "production")
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+    monkeypatch.setenv("SECRET_KEY", "super-secret-key")
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "stripe-secret")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_USER", "smtp-user")
+    monkeypatch.setenv("SMTP_PASS", "smtp-pass")
+    monkeypatch.setenv("EMAIL_FROM", "alerts@example.com")
+
+    settings = Settings()
+    assert settings.env == "production"
+    assert settings.smtp.is_configured
+    assert settings.smtp.host == "smtp.example.com"

--- a/backend/tests/test_notifier.py
+++ b/backend/tests/test_notifier.py
@@ -32,11 +32,11 @@ def test_send_email_uses_aiosmtplib(monkeypatch: pytest.MonkeyPatch) -> None:
         captured["kwargs"] = kwargs
 
     monkeypatch.setattr(notifier.aiosmtplib, "send", fake_send)
-    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
-    monkeypatch.setenv("SMTP_PORT", "2525")
-    monkeypatch.setenv("SMTP_USER", "smtp-user")
-    monkeypatch.setenv("SMTP_PASS", "smtp-pass")
-    monkeypatch.setenv("EMAIL_FROM", "alerts@example.com")
+    monkeypatch.setattr(notifier.settings.smtp, "host", "smtp.example.com")
+    monkeypatch.setattr(notifier.settings.smtp, "port", 2525)
+    monkeypatch.setattr(notifier.settings.smtp, "username", "smtp-user")
+    monkeypatch.setattr(notifier.settings.smtp, "password", "smtp-pass")
+    monkeypatch.setattr(notifier.settings.smtp, "from_address", "alerts@example.com")
 
     async def _run() -> None:
         await notifier.send_email("user@example.com", "System Update", "Hello!")


### PR DESCRIPTION
## Summary
- replace the ad-hoc config module with pydantic `BaseSettings`, including nested SMTP, QuickBooks, Google, Twilio, and threshold sections and production validation
- update alerts, notifier, inventory, invoice, job, and integrations modules to consume the structured settings objects
- add configuration validation tests, refresh notifier/alerts tests, and patch the pytest shim for Python 3.12+pydantic compatibility

## Testing
- pytest backend/tests/test_config.py backend/tests/test_notifier.py backend/tests/test_alerts_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68e20afe9b6c832c9918d980df59939c