### PR TITLE
Add staff dashboards with reusable widgets

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "npm run typecheck",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "ci:lint": "npm run lint",
     "ci:test": "npm run test",
@@ -22,6 +24,7 @@
     "@tanstack/react-query": "^5.62.9",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -36,6 +39,8 @@
     "@storybook/nextjs": "^8.4.4",
     "@storybook/react": "^8.4.4",
     "@storybook/test": "^8.4.4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -45,6 +50,8 @@
     "postcss": "^8.4.47",
     "storybook": "^8.4.4",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.8",
+    "jsdom": "^26.0.0"
   }
 }

--- a/frontend/src/app/(staff)/dashboard/_components/admin-dashboard.tsx
+++ b/frontend/src/app/(staff)/dashboard/_components/admin-dashboard.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+
+import { LowStockPartsTable } from "@/components/dashboard/low-stock-parts-table";
+import { OverdueInvoicesTable } from "@/components/dashboard/overdue-invoices-table";
+import { SummaryFilters } from "@/components/dashboard/summary-filters";
+import { SummaryGrid } from "@/components/dashboard/summary-grid";
+import {
+  useAdminSummary,
+  useLowStockParts,
+  useOverdueInvoices,
+  useSummaryCsv,
+  useTechnicianOptions,
+} from "@/hooks/use-dashboard-data";
+import type { AdminSummaryFilters } from "@/services/dashboard";
+
+function exportCsv(content: string) {
+  const blob = new Blob([content], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "admin-dashboard-summary.csv";
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function AdminDashboardView() {
+  const [filters, setFilters] = useState<AdminSummaryFilters>({ overdueOnly: true });
+  const { data: metrics, isLoading } = useAdminSummary(filters, true);
+  const { data: overdueInvoices } = useOverdueInvoices();
+  const { data: lowStock } = useLowStockParts();
+  const { data: technicians } = useTechnicianOptions();
+  const csv = useSummaryCsv(metrics ?? [], filters);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Admin command center</h1>
+        <p className="text-sm text-muted-foreground">
+          Finance-ready KPIs, receivables aging, and replenishment signals consolidated from the API.
+        </p>
+      </header>
+      <SummaryFilters filters={filters} technicians={technicians ?? []} onChange={setFilters} />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          Export respects technician, job status, and overdue filters via query parameters.
+        </p>
+        <button
+          type="button"
+          onClick={() => exportCsv(csv)}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground shadow hover:bg-primary/90"
+        >
+          Download CSV snapshot
+        </button>
+      </div>
+      {isLoading || !metrics ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-24 animate-pulse rounded-xl bg-muted/40" />
+          ))}
+        </div>
+      ) : (
+        <SummaryGrid metrics={metrics} />
+      )}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <OverdueInvoicesTable invoices={overdueInvoices ?? []} />
+        <LowStockPartsTable parts={lowStock ?? []} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
+++ b/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { LowStockPartsTable } from "@/components/dashboard/low-stock-parts-table";
+import { OverdueInvoicesTable } from "@/components/dashboard/overdue-invoices-table";
+import { SummaryFilters, type TechnicianOption } from "@/components/dashboard/summary-filters";
+import { SummaryGrid } from "@/components/dashboard/summary-grid";
+import {
+  useAdminSummary,
+  useLowStockParts,
+  useOverdueInvoices,
+  useSummaryCsv,
+  useTechnicianOptions,
+} from "@/hooks/use-dashboard-data";
+import type { AdminSummaryFilters } from "@/services/dashboard";
+
+function downloadCsv(content: string, fileName: string) {
+  const blob = new Blob([content], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ManagerDashboardView() {
+  const [filters, setFilters] = useState<AdminSummaryFilters>({ overdueOnly: false });
+  const { data: metrics, isLoading } = useAdminSummary(filters, true);
+  const { data: technicians } = useTechnicianOptions();
+  const { data: overdueInvoices } = useOverdueInvoices();
+  const { data: lowStockParts } = useLowStockParts();
+  const csv = useSummaryCsv(metrics ?? [], filters);
+
+  const technicianOptions: TechnicianOption[] = useMemo(
+    () => technicians ?? [],
+    [technicians],
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Manager dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Cross-team visibility into open jobs, receivables, and inventory readiness.
+        </p>
+      </header>
+      <SummaryFilters filters={filters} technicians={technicianOptions} onChange={setFilters} />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          Filters sync with the admin summary endpoint so exports mirror your selection.
+        </p>
+        <button
+          type="button"
+          onClick={() => downloadCsv(csv, "dashboard-summary.csv")}
+          className="inline-flex items-center gap-2 rounded-md border border-border/70 bg-background px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          Export summary CSV
+        </button>
+      </div>
+      {isLoading || !metrics ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-24 animate-pulse rounded-xl bg-muted/40" />
+          ))}
+        </div>
+      ) : (
+        <SummaryGrid metrics={metrics} />
+      )}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <OverdueInvoicesTable invoices={overdueInvoices ?? []} />
+        <LowStockPartsTable parts={lowStockParts ?? []} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/dashboard/_components/technician-dashboard.tsx
+++ b/frontend/src/app/(staff)/dashboard/_components/technician-dashboard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { JobTimersCard } from "@/components/dashboard/job-timers-card";
+import { useTechnicianDashboard } from "@/hooks/use-dashboard-data";
+import { useOverdueInvoices, useLowStockParts } from "@/hooks/use-dashboard-data";
+
+export function TechnicianDashboardView() {
+  const { data: dashboard, isLoading: loadingDashboard } = useTechnicianDashboard(true);
+  const { data: overdueInvoices } = useOverdueInvoices();
+  const { data: lowStockParts } = useLowStockParts();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Technician dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Monitor active jobs, timers, and open invoices assigned to your bay.
+        </p>
+      </header>
+      {loadingDashboard ? (
+        <div className="h-48 animate-pulse rounded-xl bg-muted/40" />
+      ) : (
+        <JobTimersCard dashboard={dashboard} />
+      )}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div>
+          <h2 className="mb-2 text-sm font-semibold text-foreground">Overdue invoices snapshot</h2>
+          <p className="text-xs text-muted-foreground">
+            {overdueInvoices && overdueInvoices.length > 0
+              ? `${overdueInvoices.length} invoices require follow-up.`
+              : "No overdue invoices linked to your work orders."}
+          </p>
+        </div>
+        <div>
+          <h2 className="mb-2 text-sm font-semibold text-foreground">Low stock hints</h2>
+          <p className="text-xs text-muted-foreground">
+            {lowStockParts && lowStockParts.length > 0
+              ? `${lowStockParts.length} parts are below threshold.`
+              : "All assigned parts are adequately stocked."}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/dashboard/admin/page.tsx
+++ b/frontend/src/app/(staff)/dashboard/admin/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AdminDashboardView } from "@/app/(staff)/dashboard/_components/admin-dashboard";
+
+export default function AdminDashboardPage() {
+  return <AdminDashboardView />;
+}

--- a/frontend/src/app/(staff)/dashboard/manager/page.tsx
+++ b/frontend/src/app/(staff)/dashboard/manager/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ManagerDashboardView } from "@/app/(staff)/dashboard/_components/manager-dashboard";
+
+export default function ManagerDashboardPage() {
+  return <ManagerDashboardView />;
+}

--- a/frontend/src/app/(staff)/dashboard/page.tsx
+++ b/frontend/src/app/(staff)/dashboard/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { AdminDashboardView } from "@/app/(staff)/dashboard/_components/admin-dashboard";
+import { ManagerDashboardView } from "@/app/(staff)/dashboard/_components/manager-dashboard";
+import { TechnicianDashboardView } from "@/app/(staff)/dashboard/_components/technician-dashboard";
+import { useSession } from "@/hooks/use-session";
+
+export default function DashboardPage() {
+  const { role } = useSession();
+
+  const content = useMemo(() => {
+    if (role === "ADMIN") {
+      return <AdminDashboardView />;
+    }
+    if (role === "MANAGER") {
+      return <ManagerDashboardView />;
+    }
+    return <TechnicianDashboardView />;
+  }, [role]);
+
+  return content;
+}

--- a/frontend/src/app/(staff)/layout.tsx
+++ b/frontend/src/app/(staff)/layout.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+import { StaffShell } from "@/components/layout/staff-shell";
+
+export default function StaffLayout({ children }: { children: ReactNode }) {
+  return <StaffShell>{children}</StaffShell>;
+}

--- a/frontend/src/components/dashboard/job-timers-card.stories.tsx
+++ b/frontend/src/components/dashboard/job-timers-card.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { JobTimersCard } from "@/components/dashboard/job-timers-card";
+import type { TechnicianDashboardView } from "@/services/dashboard-mappers";
+
+const dashboard: TechnicianDashboardView = {
+  activeTimerCount: 2,
+  activeTimers: [
+    {
+      id: "job-1",
+      jobId: "job-1",
+      jobTitle: "Brake replacement",
+      startedAt: new Date("2024-01-10T10:00:00Z"),
+      elapsedSeconds: 3600,
+      elapsedLabel: "about 1 hour ago",
+      progressPercent: 45,
+    },
+    {
+      id: "job-2",
+      jobId: "job-2",
+      jobTitle: "AC diagnostics",
+      startedAt: new Date("2024-01-10T11:00:00Z"),
+      elapsedSeconds: 1200,
+      elapsedLabel: "20 minutes ago",
+      progressPercent: 20,
+    },
+  ],
+  assignedJobs: [
+    {
+      id: "job-1",
+      title: "Brake replacement",
+      status: "IN_PROGRESS",
+      dueDateLabel: "Due in 3 hours",
+    },
+    {
+      id: "job-2",
+      title: "AC diagnostics",
+      status: "QUEUED",
+      dueDateLabel: "Promise in 5 hours",
+    },
+  ],
+};
+
+const meta: Meta<typeof JobTimersCard> = {
+  title: "Dashboard/JobTimersCard",
+  component: JobTimersCard,
+  args: {
+    dashboard,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof JobTimersCard>;
+
+export const Default: Story = {};

--- a/frontend/src/components/dashboard/job-timers-card.tsx
+++ b/frontend/src/components/dashboard/job-timers-card.tsx
@@ -1,0 +1,79 @@
+import { Fragment } from "react";
+
+import type { JobTimerView, TechnicianDashboardView } from "@/services/dashboard-mappers";
+
+function TimerRow({ timer }: { timer: JobTimerView }) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-background/70 p-4 shadow-sm">
+      <div className="flex items-center justify-between text-sm font-medium text-foreground">
+        <span>{timer.jobTitle}</span>
+        <span className="text-xs text-muted-foreground">{timer.elapsedLabel}</span>
+      </div>
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${Math.max(timer.progressPercent, 4)}%` }}
+        />
+      </div>
+      <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+        <span>{Math.round(timer.elapsedSeconds / 60)} minutes logged</span>
+        <span>Progress {timer.progressPercent}%</span>
+      </div>
+    </div>
+  );
+}
+
+type JobTimersCardProps = {
+  dashboard: TechnicianDashboardView | undefined;
+};
+
+export function JobTimersCard({ dashboard }: JobTimersCardProps) {
+  if (!dashboard) {
+    return null;
+  }
+
+  const { activeTimers, assignedJobs } = dashboard;
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[2fr,1fr]">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-foreground">Active job timers</h3>
+          <span className="text-xs text-muted-foreground">{activeTimers.length} running</span>
+        </div>
+        {activeTimers.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border/70 bg-background/60 p-6 text-center text-sm text-muted-foreground">
+            No technicians are currently clocked in.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {activeTimers.map((timer) => (
+              <TimerRow key={timer.id} timer={timer} />
+            ))}
+          </div>
+        )}
+      </div>
+      <aside className="rounded-xl border border-border/60 bg-background/70 p-4">
+        <h4 className="text-sm font-semibold text-foreground">Assigned jobs</h4>
+        <p className="text-xs text-muted-foreground">
+          Track work-in-progress and promised delivery windows.
+        </p>
+        <div className="mt-3 space-y-2">
+          {assignedJobs.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No assigned jobs.</p>
+          ) : (
+            assignedJobs.map((job) => (
+              <Fragment key={job.id}>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium text-foreground">{job.title}</span>
+                  <span className="text-muted-foreground">{job.status}</span>
+                </div>
+                <p className="text-[11px] text-muted-foreground">{job.dueDateLabel}</p>
+              </Fragment>
+            ))
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/low-stock-parts-table.stories.tsx
+++ b/frontend/src/components/dashboard/low-stock-parts-table.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { LowStockPartsTable } from "@/components/dashboard/low-stock-parts-table";
+
+const meta: Meta<typeof LowStockPartsTable> = {
+  title: "Dashboard/LowStockPartsTable",
+  component: LowStockPartsTable,
+  args: {
+    parts: [
+      {
+        id: "part-1",
+        sku: "BRK-101",
+        description: "Brake pads",
+        quantity: 3,
+        reorderMin: 8,
+        suggestedOrder: 13,
+      },
+      {
+        id: "part-2",
+        sku: "FLT-210",
+        description: "Oil filter",
+        quantity: 5,
+        reorderMin: 12,
+        suggestedOrder: 19,
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LowStockPartsTable>;
+
+export const Default: Story = {};

--- a/frontend/src/components/dashboard/low-stock-parts-table.tsx
+++ b/frontend/src/components/dashboard/low-stock-parts-table.tsx
@@ -1,0 +1,50 @@
+import type { LowStockPartRow } from "@/services/dashboard-mappers";
+
+type LowStockPartsTableProps = {
+  parts: LowStockPartRow[];
+};
+
+export function LowStockPartsTable({ parts }: LowStockPartsTableProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/80">
+      <div className="border-b border-border/60 px-4 py-3">
+        <h3 className="text-sm font-semibold text-foreground">Low stock parts</h3>
+        <p className="text-xs text-muted-foreground">Parts below reorder minimum based on current inventory.</p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border/60 text-sm">
+          <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left">SKU</th>
+              <th scope="col" className="px-4 py-2 text-left">Description</th>
+              <th scope="col" className="px-4 py-2 text-right">On Hand</th>
+              <th scope="col" className="px-4 py-2 text-right">Min</th>
+              <th scope="col" className="px-4 py-2 text-right">Suggested Order</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {parts.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-xs text-muted-foreground">
+                  All parts are currently above threshold.
+                </td>
+              </tr>
+            ) : (
+              parts.map((part) => (
+                <tr key={part.id} className="hover:bg-accent/50">
+                  <td className="px-4 py-3 font-mono text-xs">{part.sku}</td>
+                  <td className="px-4 py-3 text-xs text-foreground">{part.description}</td>
+                  <td className="px-4 py-3 text-right text-sm font-medium">{part.quantity}</td>
+                  <td className="px-4 py-3 text-right text-xs text-muted-foreground">{part.reorderMin}</td>
+                  <td className="px-4 py-3 text-right text-sm font-semibold text-primary">
+                    {part.suggestedOrder}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/overdue-invoices-table.stories.tsx
+++ b/frontend/src/components/dashboard/overdue-invoices-table.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { OverdueInvoicesTable } from "@/components/dashboard/overdue-invoices-table";
+
+const meta: Meta<typeof OverdueInvoicesTable> = {
+  title: "Dashboard/OverdueInvoicesTable",
+  component: OverdueInvoicesTable,
+  args: {
+    invoices: [
+      { id: "INV-1001", status: "OVERDUE", total: 342.5 },
+      { id: "INV-1002", status: "OVERDUE", total: 129.99 },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OverdueInvoicesTable>;
+
+export const Default: Story = {};

--- a/frontend/src/components/dashboard/overdue-invoices-table.tsx
+++ b/frontend/src/components/dashboard/overdue-invoices-table.tsx
@@ -1,0 +1,48 @@
+import type { OverdueInvoiceRow } from "@/services/dashboard-mappers";
+
+type OverdueInvoicesTableProps = {
+  invoices: OverdueInvoiceRow[];
+};
+
+export function OverdueInvoicesTable({ invoices }: OverdueInvoicesTableProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/80">
+      <div className="border-b border-border/60 px-4 py-3">
+        <h3 className="text-sm font-semibold text-foreground">Overdue invoices</h3>
+        <p className="text-xs text-muted-foreground">Receivables flagged by the accounting service.</p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border/60 text-sm">
+          <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left">Invoice ID</th>
+              <th scope="col" className="px-4 py-2 text-left">Status</th>
+              <th scope="col" className="px-4 py-2 text-right">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {invoices.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-center text-xs text-muted-foreground">
+                  All invoices are current. Nice work!
+                </td>
+              </tr>
+            ) : (
+              invoices.map((invoice) => (
+                <tr key={invoice.id} className="hover:bg-accent/50">
+                  <td className="px-4 py-3 font-mono text-xs text-foreground">{invoice.id}</td>
+                  <td className="px-4 py-3 text-xs font-medium uppercase text-amber-600 dark:text-amber-400">
+                    {invoice.status}
+                  </td>
+                  <td className="px-4 py-3 text-right text-sm font-semibold text-foreground">
+                    ${invoice.total.toFixed(2)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/stat-card.tsx
+++ b/frontend/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from "react";
+import { clsx } from "clsx";
+
+type StatCardProps = {
+  title: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  icon?: ReactNode;
+  tone?: "default" | "success" | "warning" | "critical";
+};
+
+const toneClasses: Record<NonNullable<StatCardProps["tone"]>, string> = {
+  default: "border-border/70",
+  success: "border-emerald-500/30 bg-emerald-500/5",
+  warning: "border-amber-500/30 bg-amber-500/5",
+  critical: "border-red-500/30 bg-red-500/5",
+};
+
+export function StatCard({ title, value, hint, icon, tone = "default" }: StatCardProps) {
+  return (
+    <div
+      className={clsx(
+        "flex flex-col gap-2 rounded-xl border bg-background/80 p-4 shadow-sm",
+        toneClasses[tone],
+      )}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        {icon && <span className="text-foreground/70">{icon}</span>}
+        {title}
+      </div>
+      <div className="text-2xl font-semibold tracking-tight text-foreground">{value}</div>
+      {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/summary-filters.tsx
+++ b/frontend/src/components/dashboard/summary-filters.tsx
@@ -1,0 +1,80 @@
+import { ChangeEvent } from "react";
+
+import type { AdminSummaryFilters } from "@/services/dashboard";
+
+export type TechnicianOption = { value: string; label: string };
+
+type SummaryFiltersProps = {
+  filters: AdminSummaryFilters;
+  technicians: TechnicianOption[];
+  onChange: (filters: AdminSummaryFilters) => void;
+};
+
+const jobStatuses = [
+  "QUEUED",
+  "IN_PROGRESS",
+  "ON_HOLD",
+  "COMPLETED",
+];
+
+export function SummaryFilters({ filters, technicians, onChange }: SummaryFiltersProps) {
+  const handleStatusChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value || undefined;
+    onChange({ ...filters, status: next });
+  };
+
+  const handleTechnicianChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    onChange({ ...filters, technicianId: value || undefined });
+  };
+
+  const handleOverdueToggle = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...filters, overdueOnly: event.target.checked });
+  };
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <label className="flex flex-col text-xs">
+        <span className="mb-1 text-muted-foreground">Job status</span>
+        <select
+          value={filters.status ?? ""}
+          onChange={handleStatusChange}
+          className="min-w-[160px] rounded-md border border-border/70 bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+        >
+          <option value="">All statuses</option>
+          {jobStatuses.map((status) => (
+            <option key={status} value={status}>
+              {status.replace(/_/g, " ")}
+            </option>
+          ))}
+        </select>
+      </label>
+      {technicians.length > 0 && (
+        <label className="flex flex-col text-xs">
+          <span className="mb-1 text-muted-foreground">Technician</span>
+          <select
+            value={filters.technicianId ?? ""}
+            onChange={handleTechnicianChange}
+            className="min-w-[200px] rounded-md border border-border/70 bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">All technicians</option>
+            {technicians.map((tech) => (
+              <option key={tech.value} value={tech.value}>
+                {tech.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      <label className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={Boolean(filters.overdueOnly)}
+          onChange={handleOverdueToggle}
+          className="h-4 w-4 rounded border-border/70 text-primary focus:ring-primary/40"
+        />
+        Overdue invoices only
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/summary-grid.stories.tsx
+++ b/frontend/src/components/dashboard/summary-grid.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SummaryGrid } from "@/components/dashboard/summary-grid";
+
+const meta: Meta<typeof SummaryGrid> = {
+  title: "Dashboard/SummaryGrid",
+  component: SummaryGrid,
+  args: {
+    metrics: [
+      { id: "open_jobs", label: "Open Jobs", value: 12 },
+      { id: "overdue_invoices", label: "Overdue Invoices", value: 3 },
+      { id: "parts_to_reorder", label: "Parts to Reorder", value: 7 },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SummaryGrid>;
+
+export const Default: Story = {};

--- a/frontend/src/components/dashboard/summary-grid.tsx
+++ b/frontend/src/components/dashboard/summary-grid.tsx
@@ -1,0 +1,26 @@
+import { StatCard } from "@/components/dashboard/stat-card";
+import type { AdminSummaryMetric } from "@/services/dashboard-mappers";
+
+type SummaryGridProps = {
+  metrics: AdminSummaryMetric[];
+};
+
+const metricTone: Record<string, "default" | "warning" | "critical" | "success"> = {
+  overdue_invoices: "warning",
+  parts_to_reorder: "critical",
+};
+
+export function SummaryGrid({ metrics }: SummaryGridProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {metrics.map((metric) => (
+        <StatCard
+          key={metric.id}
+          title={metric.label}
+          value={metric.value}
+          tone={metricTone[metric.id] ?? "default"}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/staff-shell.tsx
+++ b/frontend/src/components/layout/staff-shell.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { ReactNode, useMemo, useState } from "react";
+import { clsx } from "clsx";
+
+import { useDashboardNotifications } from "@/hooks/use-dashboard-data";
+import { useSession } from "@/hooks/use-session";
+import { useLayoutStore } from "@/stores/layout-store";
+import type { DashboardNotification } from "@/services/dashboard-mappers";
+
+const navigationByRole: Record<string, Array<{ label: string; href: string }>> = {
+  TECHNICIAN: [
+    { label: "My Dashboard", href: "/dashboard" },
+    { label: "Manager View", href: "/dashboard/manager" },
+  ],
+  MANAGER: [
+    { label: "Manager Dashboard", href: "/dashboard/manager" },
+    { label: "Technician View", href: "/dashboard" },
+    { label: "Admin Summary", href: "/dashboard/admin" },
+  ],
+  ADMIN: [
+    { label: "Admin Dashboard", href: "/dashboard/admin" },
+    { label: "Manager Dashboard", href: "/dashboard/manager" },
+    { label: "Technician Dashboard", href: "/dashboard" },
+  ],
+};
+
+const statusColor: Record<string, string> = {
+  info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  muted: "bg-muted text-muted-foreground",
+};
+
+type StaffShellProps = {
+  children: ReactNode;
+};
+
+export function StaffShell({ children }: StaffShellProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isSidebarOpen, toggleSidebar, closeSidebar } = useLayoutStore();
+  const { user, isAuthenticated, role, isLoading } = useSession();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const breadcrumbs = useMemo(() => {
+    if (!pathname) {
+      return [];
+    }
+    const segments = pathname.split("/").filter(Boolean);
+    return segments.map((segment, index) => {
+      const href = `/${segments.slice(0, index + 1).join("/")}`;
+      const label = segment
+        .replace(/\(.*\)/g, "")
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (match) => match.toUpperCase())
+        .trim();
+      return { href, label: label || "Dashboard" };
+    });
+  }, [pathname]);
+
+  const navigation = navigationByRole[role ?? ""] ?? [{ label: "Dashboard", href: "/dashboard" }];
+  const { data: notifications } = useDashboardNotifications(role ?? null);
+
+  if (!isAuthenticated && !isLoading) {
+    router.replace("/login");
+  }
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+      router.replace("/login");
+      router.refresh();
+    } finally {
+      setIsSigningOut(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/90 backdrop-blur">
+        <div className="container flex h-16 items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border text-foreground transition-colors hover:bg-accent lg:hidden"
+              aria-label="Toggle navigation"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+              </svg>
+            </button>
+            <Link href="/dashboard" className="flex items-center gap-2 text-sm font-semibold">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground shadow">AR</span>
+              <span className="hidden sm:inline">Staff Operations</span>
+            </Link>
+          </div>
+          <div className="flex items-center gap-4">
+            <Breadcrumbs items={breadcrumbs} />
+            <NotificationCenter notifications={notifications ?? []} />
+            {isAuthenticated && (
+              <div className="hidden flex-col text-xs leading-tight sm:flex">
+                <span className="font-semibold text-foreground">{user?.email}</span>
+                <span className="uppercase tracking-wide text-muted-foreground">{role}</span>
+              </div>
+            )}
+            {isAuthenticated && (
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="inline-flex items-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                disabled={isSigningOut}
+              >
+                {isSigningOut ? "Signing out…" : "Sign out"}
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+      <div className="flex flex-1">
+        <aside
+          className={clsx(
+            "fixed inset-y-0 left-0 z-30 w-64 border-r border-border/60 bg-background/95 px-4 py-6 transition-transform duration-200 ease-in-out lg:static lg:translate-x-0",
+            isSidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0",
+          )}
+        >
+          <nav className="space-y-1">
+            {navigation.map((item) => {
+              const isActive = pathname === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={closeSidebar}
+                  className={clsx(
+                    "flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-primary/10 text-primary shadow"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                  )}
+                >
+                  {item.label}
+                  {isActive && (
+                    <span className="inline-flex h-2 w-2 rounded-full bg-primary" />
+                  )}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+        {isSidebarOpen && (
+          <button
+            type="button"
+            aria-label="Close sidebar overlay"
+            className="fixed inset-0 z-20 bg-black/40 backdrop-blur-sm lg:hidden"
+            onClick={closeSidebar}
+          />
+        )}
+        <main className="flex-1 bg-gradient-to-b from-background to-background/90">
+          <div className="container py-8">
+            <div className="rounded-xl border border-border/60 bg-card/80 p-6 shadow-sm backdrop-blur">
+              {children}
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+type BreadcrumbsProps = {
+  items: Array<{ href: string; label: string }>;
+};
+
+function Breadcrumbs({ items }: BreadcrumbsProps) {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex">
+      {items.map((item, index) => (
+        <span key={item.href} className="flex items-center gap-1">
+          {index > 0 && <span className="opacity-50">/</span>}
+          <Link href={item.href} className="hover:text-foreground">
+            {item.label}
+          </Link>
+        </span>
+      ))}
+    </nav>
+  );
+}
+
+type NotificationCenterProps = {
+  notifications: DashboardNotification[];
+};
+
+function NotificationCenter({ notifications }: NotificationCenterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const unseenCount = notifications.length;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((value) => !value)}
+        className="relative inline-flex h-10 w-10 items-center justify-center rounded-md border border-border text-foreground transition-colors hover:bg-accent"
+        aria-label="Toggle notifications"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0 1 18 14.158V11a6.002 6.002 0 0 0-4-5.659V5a2 2 0 1 0-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 1 1-6 0v-1m6 0H9" />
+        </svg>
+        {unseenCount > 0 && (
+          <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+            {unseenCount}
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 z-40 mt-2 w-72 rounded-lg border border-border/60 bg-popover p-3 text-sm shadow-lg">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="font-semibold text-foreground">Notifications</span>
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Close
+            </button>
+          </div>
+          {notifications.length === 0 ? (
+            <p className="text-xs text-muted-foreground">You're all caught up.</p>
+          ) : (
+            <ul className="space-y-2">
+              {notifications.map((notification) => (
+                <li key={notification.id} className={clsx("rounded-md px-3 py-2 text-xs", statusColor[notification.severity])}>
+                  <p className="font-medium">{notification.title}</p>
+                  <p className="text-xs opacity-80">{notification.description}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/hooks/__tests__/use-dashboard-data.test.tsx
+++ b/frontend/src/hooks/__tests__/use-dashboard-data.test.tsx
@@ -1,0 +1,118 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useAdminSummary,
+  useDashboardNotifications,
+  useTechnicianDashboard,
+} from "@/hooks/use-dashboard-data";
+import {
+  fetchAdminSummary,
+  fetchBayOverloadAlerts,
+  fetchHighSubstitutionAlerts,
+  fetchOverdueInvoiceCount,
+  fetchTechnicianDashboard,
+  fetchTechnicianOverlapAlerts,
+  fetchTechnicianPartsSummary,
+} from "@/services/dashboard";
+
+vi.mock("@/services/dashboard", () => ({
+  fetchTechnicianDashboard: vi.fn().mockResolvedValue({
+    active_timers: [
+      {
+        jobId: "job-1",
+        startedAt: "2024-01-10T10:00:00Z",
+        elapsedSeconds: 1200,
+        jobTitle: "Oil change",
+      },
+    ],
+    assigned_jobs: [
+      { id: "job-1", title: "Oil change", status: "IN_PROGRESS", dueDate: "2024-01-10T13:00:00Z" },
+    ],
+  }),
+  fetchAdminSummary: vi.fn().mockResolvedValue({
+    open_jobs: 4,
+    overdue_invoices: 2,
+    parts_to_reorder: 3,
+  }),
+  fetchOverdueInvoices: vi.fn().mockResolvedValue([]),
+  fetchLowStockCandidates: vi.fn().mockResolvedValue([]),
+  fetchTechnicians: vi.fn().mockResolvedValue([{ id: "tech-1", email: "tech@example.com", role: "TECHNICIAN" }]),
+  fetchTechnicianPartsSummary: vi.fn().mockResolvedValue({
+    parts_received_today: 1,
+    parts_received_week: 5,
+    events_today: 2,
+    events_week: 6,
+  }),
+  fetchHighSubstitutionAlerts: vi.fn().mockResolvedValue({ alerted_skus: ["SKU-1"] }),
+  fetchBayOverloadAlerts: vi.fn().mockResolvedValue({ alerts: [{ bay: "A1", date: "2024-01-09", job_count: 12 }] }),
+  fetchTechnicianOverlapAlerts: vi.fn().mockResolvedValue({ overlap_alerts: [{ technician_id: "t1", date: "2024-01-09", bays: ["A1"] }] }),
+  fetchOverdueInvoiceCount: vi.fn().mockResolvedValue({
+    open_jobs: 0,
+    overdue_invoices: 5,
+    parts_to_reorder: 0,
+  }),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useTechnicianDashboard", () => {
+  it("returns mapped technician data", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useTechnicianDashboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.activeTimers).toHaveLength(1);
+    expect(fetchTechnicianDashboard).toHaveBeenCalled();
+  });
+});
+
+describe("useAdminSummary", () => {
+  it("requests data with provided filters", async () => {
+    const wrapper = createWrapper();
+    const filters = { status: "IN_PROGRESS", overdueOnly: true, technicianId: "tech-1" };
+    const { result } = renderHook(() => useAdminSummary(filters), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchAdminSummary).toHaveBeenCalledWith(filters);
+    expect(result.current.data?.[0].value).toBe(4);
+  });
+});
+
+describe("useDashboardNotifications", () => {
+  it("maps technician notifications", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDashboardNotifications("TECHNICIAN"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchTechnicianPartsSummary).toHaveBeenCalled();
+    expect(result.current.data?.[0].title).toContain("Parts");
+  });
+
+  it("aggregates admin notifications", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDashboardNotifications("ADMIN"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchHighSubstitutionAlerts).toHaveBeenCalled();
+    expect(fetchBayOverloadAlerts).toHaveBeenCalled();
+    expect(fetchTechnicianOverlapAlerts).toHaveBeenCalled();
+    expect(fetchOverdueInvoiceCount).toHaveBeenCalled();
+    expect(result.current.data?.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/hooks/use-dashboard-data.ts
+++ b/frontend/src/hooks/use-dashboard-data.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  fetchAdminSummary,
+  fetchBayOverloadAlerts,
+  fetchHighSubstitutionAlerts,
+  fetchLowStockCandidates,
+  fetchOverdueInvoiceCount,
+  fetchOverdueInvoices,
+  fetchTechnicianDashboard,
+  fetchTechnicianOverlapAlerts,
+  fetchTechnicianPartsSummary,
+  fetchTechnicians,
+} from "@/services/dashboard";
+import type { AdminSummaryFilters } from "@/services/dashboard";
+import {
+  buildSummaryCsv,
+  mapAdminSummary,
+  mapLowStockParts,
+  mapOverdueInvoices,
+  mapTechnicianDashboard,
+  mapTechnicianPartsSummary,
+} from "@/services/dashboard-mappers";
+import type {
+  AdminSummaryMetric,
+  DashboardNotification,
+  LowStockPartRow,
+  OverdueInvoiceRow,
+  TechnicianDashboardView,
+} from "@/services/dashboard-mappers";
+
+export function useTechnicianDashboard(enabled = true) {
+  return useQuery<TechnicianDashboardView>({
+    queryKey: ["dashboard", "technician"],
+    queryFn: async () => {
+      const response = await fetchTechnicianDashboard();
+      return mapTechnicianDashboard(response);
+    },
+    enabled,
+  });
+}
+
+export function useAdminSummary(filters: AdminSummaryFilters, enabled = true) {
+  return useQuery<AdminSummaryMetric[]>({
+    queryKey: ["dashboard", "admin-summary", filters],
+    queryFn: async () => {
+      const response = await fetchAdminSummary(filters);
+      return mapAdminSummary(response);
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useOverdueInvoices(enabled = true) {
+  return useQuery<OverdueInvoiceRow[]>({
+    queryKey: ["dashboard", "overdue-invoices"],
+    queryFn: async () => {
+      const response = await fetchOverdueInvoices();
+      return mapOverdueInvoices(response);
+    },
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+export function useLowStockParts(enabled = true) {
+  return useQuery<LowStockPartRow[]>({
+    queryKey: ["dashboard", "low-stock-parts"],
+    queryFn: async () => {
+      const parts = await fetchLowStockCandidates();
+      return mapLowStockParts(parts);
+    },
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useTechnicianOptions() {
+  return useQuery({
+    queryKey: ["dashboard", "technicians"],
+    queryFn: async () => {
+      const technicians = await fetchTechnicians();
+      return technicians.map((tech) => ({ value: tech.id, label: tech.email }));
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useDashboardNotifications(role: string | null) {
+  return useQuery<DashboardNotification[]>({
+    queryKey: ["dashboard", "notifications", role],
+    queryFn: async () => {
+      if (!role) {
+        return [];
+      }
+
+      if (role === "TECHNICIAN") {
+        const summary = await fetchTechnicianPartsSummary();
+        return mapTechnicianPartsSummary(summary);
+      }
+
+      const [subs, bays, overlap, overdue] = await Promise.allSettled([
+        fetchHighSubstitutionAlerts(),
+        fetchBayOverloadAlerts(),
+        fetchTechnicianOverlapAlerts(),
+        fetchOverdueInvoiceCount(),
+      ]);
+
+      const notifications: DashboardNotification[] = [];
+
+      if (subs.status === "fulfilled" && subs.value.alerted_skus.length > 0) {
+        notifications.push({
+          id: "substitution-alert",
+          title: "High substitution volume",
+          description: `${subs.value.alerted_skus.length} SKUs need review`,
+          severity: "warning",
+        });
+      }
+
+      if (bays.status === "fulfilled" && bays.value.alerts.length > 0) {
+        const latest = bays.value.alerts[0];
+        notifications.push({
+          id: "bay-overload",
+          title: "Bay capacity warning",
+          description: `${latest.bay} handled ${latest.job_count} jobs on ${latest.date}`,
+          severity: "info",
+        });
+      }
+
+      if (overlap.status === "fulfilled" && overlap.value.overlap_alerts.length > 0) {
+        notifications.push({
+          id: "tech-overlap",
+          title: "Technician double-booked",
+          description: `${overlap.value.overlap_alerts.length} technicians need schedule review`,
+          severity: "warning",
+        });
+      }
+
+      if (
+        overdue.status === "fulfilled" &&
+        (overdue.value.overdue_invoices ?? 0) > 0
+      ) {
+        notifications.push({
+          id: "overdue-invoices",
+          title: "Overdue invoices",
+          description: `${overdue.value.overdue_invoices} receivables require follow-up`,
+          severity: "info",
+        });
+      }
+
+      return notifications;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useSummaryCsv(metrics: AdminSummaryMetric[], filters: AdminSummaryFilters) {
+  return useMemo(() => buildSummaryCsv(metrics, filters), [metrics, filters]);
+}

--- a/frontend/src/services/__tests__/dashboard-mappers.test.ts
+++ b/frontend/src/services/__tests__/dashboard-mappers.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildSummaryCsv,
+  mapAdminSummary,
+  mapLowStockParts,
+  mapOverdueInvoices,
+  mapTechnicianDashboard,
+  mapTechnicianPartsSummary,
+} from "@/services/dashboard-mappers";
+import type { TechnicianDashboardResponse } from "@/services/dashboard";
+
+describe("dashboard mappers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-10T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("maps technician dashboard data", () => {
+    const payload: TechnicianDashboardResponse = {
+      active_timers: [
+        {
+          jobId: "job-123",
+          startedAt: "2024-01-10T10:00:00Z",
+          elapsedSeconds: 3600,
+          jobTitle: "Brake replacement",
+        },
+      ],
+      assigned_jobs: [
+        {
+          id: "job-123",
+          title: "Brake replacement",
+          status: "IN_PROGRESS",
+          dueDate: "2024-01-10T17:00:00Z",
+        },
+      ],
+    };
+
+    const mapped = mapTechnicianDashboard(payload);
+    expect(mapped.activeTimers).toHaveLength(1);
+    expect(mapped.activeTimers[0]).toMatchObject({
+      jobId: "job-123",
+      progressPercent: 13,
+    });
+    expect(mapped.assignedJobs[0].dueDateLabel).toContain("Due");
+  });
+
+  it("maps admin summary metrics", () => {
+    const metrics = mapAdminSummary({
+      open_jobs: 5,
+      overdue_invoices: 2,
+      parts_to_reorder: 7,
+    });
+    expect(metrics.map((metric) => metric.value)).toEqual([5, 2, 7]);
+  });
+
+  it("maps overdue invoices", () => {
+    const invoices = mapOverdueInvoices([
+      { id: "INV-1", status: "OVERDUE", total: 123.45 },
+    ]);
+    expect(invoices[0]).toEqual({ id: "INV-1", status: "OVERDUE", total: 123.45 });
+  });
+
+  it("filters and enriches low stock parts", () => {
+    const parts = mapLowStockParts([
+      {
+        id: "part-1",
+        sku: "ABC",
+        description: "Filter",
+        quantity: 2,
+        reorderMin: 5,
+      },
+      {
+        id: "part-2",
+        sku: "DEF",
+        description: "Ignore",
+        quantity: 10,
+        reorderMin: 2,
+      },
+    ]);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].suggestedOrder).toBe(8);
+  });
+
+  it("builds CSV with filters", () => {
+    const csv = buildSummaryCsv(
+      mapAdminSummary({ open_jobs: 1, overdue_invoices: 2, parts_to_reorder: 3 }),
+      { status: "IN_PROGRESS", overdueOnly: true },
+    );
+    expect(csv).toContain("Filter: status");
+    expect(csv).toContain("IN_PROGRESS");
+  });
+
+  it("maps technician parts summary into notifications", () => {
+    const notifications = mapTechnicianPartsSummary({
+      parts_received_today: 4,
+      parts_received_week: 12,
+      events_today: 6,
+      events_week: 14,
+    });
+    expect(notifications).toHaveLength(3);
+    expect(notifications[0].severity).toBe("success");
+  });
+});

--- a/frontend/src/services/dashboard-mappers.ts
+++ b/frontend/src/services/dashboard-mappers.ts
@@ -1,0 +1,186 @@
+import { formatDistanceToNow } from "date-fns";
+
+import type {
+  AdminSummaryFilters,
+  AdminSummaryResponse,
+  InventoryPart,
+  PaymentInvoiceSummary,
+  RawJobTimer,
+  TechnicianDashboardResponse,
+  TechnicianPartsSummaryResponse,
+} from "@/services/dashboard";
+
+export interface JobTimerView {
+  id: string;
+  jobId: string;
+  jobTitle: string;
+  startedAt: Date;
+  elapsedSeconds: number;
+  elapsedLabel: string;
+  progressPercent: number;
+}
+
+export interface TechnicianDashboardView {
+  assignedJobs: Array<{
+    id: string;
+    title: string;
+    status: string;
+    dueDateLabel: string;
+  }>;
+  activeTimers: JobTimerView[];
+  activeTimerCount: number;
+}
+
+export interface AdminSummaryMetric {
+  id: string;
+  label: string;
+  value: number;
+}
+
+export interface OverdueInvoiceRow {
+  id: string;
+  status: string;
+  total: number;
+}
+
+export interface LowStockPartRow {
+  id: string;
+  sku: string;
+  description: string;
+  quantity: number;
+  reorderMin: number;
+  suggestedOrder: number;
+}
+
+export interface DashboardNotification {
+  id: string;
+  title: string;
+  description: string;
+  severity: "info" | "warning" | "success" | "muted";
+}
+
+export function mapJobTimer(timer: RawJobTimer, index: number): JobTimerView {
+  const startedAt = new Date(timer.startedAt);
+  const elapsedSeconds = timer.elapsedSeconds ?? 0;
+  const hoursBudget = 8 * 3600;
+  const progress = Math.min(100, Math.round((elapsedSeconds / hoursBudget) * 100));
+
+  return {
+    id: `${timer.jobId}-${index}`,
+    jobId: timer.jobId,
+    jobTitle: timer.jobTitle ?? `Job ${timer.jobId.slice(0, 8)}`,
+    startedAt,
+    elapsedSeconds,
+    elapsedLabel: formatDistanceToNow(startedAt, { addSuffix: true }),
+    progressPercent: Number.isFinite(progress) ? progress : 0,
+  };
+}
+
+export function mapTechnicianDashboard(
+  data: TechnicianDashboardResponse,
+): TechnicianDashboardView {
+  const activeTimers = (data.active_timers ?? []).map(mapJobTimer);
+  const assignedJobs = (data.assigned_jobs ?? []).map((job) => ({
+    id: job.id,
+    title: job.title ?? `Job ${job.id.slice(0, 6)}`,
+    status: job.status ?? "UNKNOWN",
+    dueDateLabel: job.dueDate
+      ? `Due ${formatDistanceToNow(new Date(job.dueDate), { addSuffix: true })}`
+      : job.promiseDate
+        ? `Promise ${formatDistanceToNow(new Date(job.promiseDate), { addSuffix: true })}`
+        : "No due date",
+  }));
+
+  return {
+    activeTimers,
+    assignedJobs,
+    activeTimerCount: activeTimers.length,
+  };
+}
+
+export function mapAdminSummary(data: AdminSummaryResponse): AdminSummaryMetric[] {
+  return [
+    { id: "open_jobs", label: "Open Jobs", value: data.open_jobs ?? 0 },
+    {
+      id: "overdue_invoices",
+      label: "Overdue Invoices",
+      value: data.overdue_invoices ?? 0,
+    },
+    {
+      id: "parts_to_reorder",
+      label: "Parts to Reorder",
+      value: data.parts_to_reorder ?? 0,
+    },
+  ];
+}
+
+export function mapOverdueInvoices(data: PaymentInvoiceSummary[]): OverdueInvoiceRow[] {
+  return (data ?? []).map((invoice) => ({
+    id: invoice.id,
+    status: invoice.status,
+    total: Number(invoice.total ?? 0),
+  }));
+}
+
+export function mapLowStockParts(parts: InventoryPart[]): LowStockPartRow[] {
+  return (parts ?? [])
+    .filter((part) => typeof part.reorderMin === "number" && part.reorderMin !== null)
+    .filter((part) => part.quantity < Number(part.reorderMin))
+    .map((part) => {
+      const reorderMin = Number(part.reorderMin ?? 0);
+      const suggested = Math.max(reorderMin * 2 - Number(part.quantity ?? 0), 0);
+      return {
+        id: part.id,
+        sku: part.sku,
+        description: part.description ?? "Unlabeled part",
+        quantity: Number(part.quantity ?? 0),
+        reorderMin,
+        suggestedOrder: suggested,
+      };
+    });
+}
+
+export function buildSummaryCsv(
+  metrics: AdminSummaryMetric[],
+  filters: AdminSummaryFilters,
+): string {
+  const headers = ["Metric", "Value"];
+  const filterRows = Object.entries(filters)
+    .filter(([, value]) => value !== undefined && value !== "")
+    .map(([key, value]) => [
+      `Filter: ${key.replace(/[A-Z]/g, (match) => ` ${match.toLowerCase()}`)}`,
+      Array.isArray(value) ? value.join(", ") : String(value),
+    ]);
+  const metricRows = metrics.map((metric) => [metric.label, String(metric.value)]);
+  const rows = [headers, ...filterRows, ...metricRows];
+  return rows.map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(",")).join("\n");
+}
+
+export function mapTechnicianPartsSummary(
+  summary: TechnicianPartsSummaryResponse,
+): DashboardNotification[] {
+  if (!summary) {
+    return [];
+  }
+
+  return [
+    {
+      id: "parts-today",
+      title: "Parts received today",
+      description: `${summary.parts_received_today} items scanned`,
+      severity: summary.parts_received_today > 0 ? "success" : "muted",
+    },
+    {
+      id: "parts-week",
+      title: "Parts received this week",
+      description: `${summary.parts_received_week} items scanned`,
+      severity: "info",
+    },
+    {
+      id: "events-today",
+      title: "Inventory events today",
+      description: `${summary.events_today} adjustments recorded`,
+      severity: summary.events_today > 5 ? "warning" : "muted",
+    },
+  ];
+}

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -1,0 +1,139 @@
+import { get } from "@/lib/api/client";
+import type { NormalizedApiError } from "@/lib/api/client";
+
+export interface TechnicianDashboardResponse {
+  assigned_jobs: TechnicianJob[];
+  active_timers: RawJobTimer[];
+}
+
+export interface TechnicianJob {
+  id: string;
+  title?: string | null;
+  status?: string | null;
+  promiseDate?: string | null;
+  dueDate?: string | null;
+  startedAt?: string | null;
+}
+
+export interface RawJobTimer {
+  jobId: string;
+  startedAt: string;
+  elapsedSeconds: number;
+  jobTitle?: string | null;
+}
+
+export interface AdminSummaryResponse {
+  open_jobs: number;
+  overdue_invoices: number;
+  parts_to_reorder: number;
+}
+
+export interface TechnicianUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+export interface PaymentInvoiceSummary {
+  id: string;
+  status: string;
+  total: number;
+}
+
+export interface InventoryPart {
+  id: string;
+  sku: string;
+  description?: string | null;
+  quantity: number;
+  reorderMin?: number | null;
+  maxQty?: number | null;
+  vendor?: string | null;
+}
+
+export interface TechnicianPartsSummaryResponse {
+  parts_received_today: number;
+  parts_received_week: number;
+  events_today: number;
+  events_week: number;
+}
+
+export interface HighSubstitutionResponse {
+  alerted_skus: string[];
+}
+
+export interface BayOverloadResponse {
+  alerts: Array<{ bay: string; date: string; job_count: number }>;
+}
+
+export interface TechnicianOverlapResponse {
+  overlap_alerts: Array<{ technician_id: string; date: string; bays: string[] }>;
+}
+
+export type AdminSummaryFilters = {
+  status?: string;
+  technicianId?: string;
+  overdueOnly?: boolean;
+};
+
+export async function fetchTechnicianDashboard() {
+  return get<TechnicianDashboardResponse>("/dashboard");
+}
+
+export async function fetchAdminSummary(filters: AdminSummaryFilters) {
+  return get<AdminSummaryResponse>("/dashboard/admin/summary", {
+    params: {
+      job_status: filters.status || undefined,
+      overdue_only: filters.overdueOnly ? true : undefined,
+      technician_id: filters.technicianId || undefined,
+    },
+  });
+}
+
+export async function fetchOverdueInvoices() {
+  return get<PaymentInvoiceSummary[]>("/payment/invoices", {
+    params: { status: "overdue" },
+  });
+}
+
+export async function fetchTechnicians(): Promise<TechnicianUser[]> {
+  try {
+    return await get<TechnicianUser[]>("/users", {
+      params: {
+        role: "TECHNICIAN",
+        limit: 100,
+      },
+    });
+  } catch (error) {
+    const normalized = error as NormalizedApiError;
+    if (normalized?.status === 403) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function fetchLowStockCandidates() {
+  return get<InventoryPart[]>("/inventory/parts");
+}
+
+export async function fetchTechnicianPartsSummary() {
+  return get<TechnicianPartsSummaryResponse>("/dashboard/tech/parts-summary");
+}
+
+export async function fetchHighSubstitutionAlerts() {
+  return get<HighSubstitutionResponse>("/alerts/alerts/high-substitution-parts");
+}
+
+export async function fetchBayOverloadAlerts() {
+  return get<BayOverloadResponse>("/alerts/alerts/overutilized-bays");
+}
+
+export async function fetchTechnicianOverlapAlerts() {
+  return get<TechnicianOverlapResponse>("/alerts/alerts/tech-overlap");
+}
+
+export async function fetchOverdueInvoiceCount() {
+  return get<AdminSummaryResponse>("/dashboard/admin/summary", {
+    params: { overdue_only: true },
+  });
+}

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "typeRoots": ["./types", "./node_modules/@types"],
     "incremental": true,
     "plugins": [
       {

--- a/frontend/types/json5/index.d.ts
+++ b/frontend/types/json5/index.d.ts
@@ -1,0 +1,4 @@
+declare module "json5" {
+  const json5: unknown;
+  export default json5;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/tests/setup.ts"],
+    coverage: {
+      reporter: ["text", "json", "html"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a role-aware staff layout with breadcrumbs, sidebar navigation, and notification center
- implement technician, manager, and admin dashboard pages backed by new React Query hooks and services
- create reusable dashboard cards/tables, Storybook stories, and Vitest coverage for mappers and hooks

## Testing
- `npm run test` *(fails: vitest executable unavailable in environment)*
- `npm run typecheck` *(fails: existing project type errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e68fd20168832c87fc945e1a53d529