### PR TITLE
feat: add customer portal and staff customer management

### DIFF
--- a/frontend/src/app/(portal)/portal/dashboard/page.tsx
+++ b/frontend/src/app/(portal)/portal/dashboard/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { PdfDownloadButton } from "@/components/customers";
+import { getCustomerDashboard } from "@/services/customers";
+
+export default function CustomerDashboardPage() {
+  const dashboardQuery = useQuery({
+    queryKey: ["portal", "dashboard"],
+    queryFn: getCustomerDashboard,
+  });
+
+  if (dashboardQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading your dashboard…</p>;
+  }
+
+  if (dashboardQuery.isError || !dashboardQuery.data) {
+    return <p className="text-sm text-destructive">Unable to load dashboard data.</p>;
+  }
+
+  const { estimates, invoices, vehicles, appointments } = dashboardQuery.data;
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Welcome back</h1>
+        <p className="text-sm text-muted-foreground">
+          Track upcoming appointments, download documents, and review your vehicles at a glance.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Recent invoices</h2>
+          {invoices.length ? (
+            <ul className="space-y-3">
+              {invoices.slice(0, 5).map((invoice) => (
+                <li key={invoice.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-foreground">Invoice #{invoice.id}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {invoice.status ?? "PENDING"} · ${invoice.total?.toFixed(2) ?? "0.00"}
+                      </p>
+                    </div>
+                    <PdfDownloadButton href={`/invoices/${invoice.id}/pdf`}>
+                      Download PDF
+                    </PdfDownloadButton>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No invoices available.</p>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Pending estimates</h2>
+          {estimates.length ? (
+            <ul className="space-y-3">
+              {estimates.slice(0, 5).map((estimate) => (
+                <li key={estimate.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-foreground">Estimate #{estimate.id}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {estimate.status ?? "DRAFT"} · ${estimate.total?.toFixed(2) ?? "0.00"}
+                      </p>
+                    </div>
+                    <PdfDownloadButton href={`/estimates/${estimate.id}/pdf`}>
+                      Download PDF
+                    </PdfDownloadButton>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No estimates to review.</p>
+          )}
+        </section>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Your vehicles</h2>
+          {vehicles.length ? (
+            <ul className="space-y-3">
+              {vehicles.map((vehicle) => (
+                <li key={vehicle.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                  <p className="font-medium text-foreground">
+                    {vehicle.year} {vehicle.make} {vehicle.model}
+                  </p>
+                  <p className="text-xs text-muted-foreground">VIN {vehicle.vin}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">We don't have any vehicles on file yet.</p>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Upcoming appointments</h2>
+          {appointments.length ? (
+            <ul className="space-y-3">
+              {appointments.map((appointment) => (
+                <li key={appointment.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                  <p className="font-medium text-foreground">{appointment.serviceType ?? "Service"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {appointment.startTime
+                      ? new Date(appointment.startTime).toLocaleString()
+                      : "Date to be scheduled"}
+                    {appointment.status ? ` · ${appointment.status}` : ""}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No appointments scheduled.</p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(portal)/portal/layout.tsx
+++ b/frontend/src/app/(portal)/portal/layout.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+import { PortalShell } from "@/components/layout/portal-shell";
+
+export default function PortalLayout({ children }: { children: ReactNode }) {
+  return <PortalShell>{children}</PortalShell>;
+}

--- a/frontend/src/app/(portal)/portal/page.tsx
+++ b/frontend/src/app/(portal)/portal/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function PortalIndexPage() {
+  redirect("/portal/dashboard");
+}

--- a/frontend/src/app/(portal)/portal/profile/page.tsx
+++ b/frontend/src/app/(portal)/portal/profile/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  CustomerUpdateValues,
+  customerUpdateSchema,
+} from "@/components/customers";
+import {
+  Customer,
+  getCustomerSelf,
+  updateCustomerSelf,
+} from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export default function CustomerProfilePage() {
+  const queryClient = useQueryClient();
+  const profileQuery = useQuery<Customer>({
+    queryKey: ["portal", "profile"],
+    queryFn: getCustomerSelf,
+  });
+
+  const mutation = useMutation({
+    mutationFn: updateCustomerSelf,
+    onSuccess: (response) => {
+      queryClient.setQueryData(["portal", "profile"], response.customer);
+      showToast({
+        title: "Profile updated",
+        description: "Your contact information has been saved.",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to update profile")
+          : "Unable to update profile";
+      showToast({
+        title: "Update failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const form = useForm<CustomerUpdateValues>({
+    resolver: zodResolver(customerUpdateSchema),
+    values: profileQuery.data
+      ? {
+          fullName: profileQuery.data.fullName,
+          email: profileQuery.data.email,
+          phone: profileQuery.data.phone,
+          street: profileQuery.data.street ?? "",
+          city: profileQuery.data.city ?? "",
+          state: profileQuery.data.state ?? "",
+          zip: profileQuery.data.zip ?? "",
+        }
+      : undefined,
+  });
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await mutation.mutateAsync(values);
+  });
+
+  if (profileQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading your profile…</p>;
+  }
+
+  if (profileQuery.isError || !profileQuery.data) {
+    return <p className="text-sm text-destructive">Unable to load your profile.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Your profile</h1>
+        <p className="text-sm text-muted-foreground">
+          Update your contact and mailing information. Changes apply immediately across the portal.
+        </p>
+      </header>
+
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Field label="Full name" error={form.formState.errors.fullName?.message}>
+            <input
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("fullName")}
+            />
+          </Field>
+          <Field label="Email" error={form.formState.errors.email?.message}>
+            <input
+              type="email"
+              className="w-full rounded-md border border-border/70 bg-muted px-3 py-2 text-sm shadow-sm"
+              disabled
+              {...form.register("email")}
+            />
+          </Field>
+          <Field label="Phone" error={form.formState.errors.phone?.message}>
+            <input
+              type="tel"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("phone")}
+            />
+          </Field>
+          <Field label="Street" error={form.formState.errors.street?.message}>
+            <input
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("street")}
+            />
+          </Field>
+          <Field label="City" error={form.formState.errors.city?.message}>
+            <input
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("city")}
+            />
+          </Field>
+          <Field label="State" error={form.formState.errors.state?.message}>
+            <input
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("state")}
+            />
+          </Field>
+          <Field label="ZIP" error={form.formState.errors.zip?.message}>
+            <input
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("zip")}
+            />
+          </Field>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-sm text-muted-foreground">We use this information to confirm appointments and send updates.</p>
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? "Saving…" : "Save profile"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+type FieldProps = {
+  label: string;
+  error?: string;
+  children: ReactNode;
+};
+
+function Field({ label, error, children }: FieldProps) {
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-medium text-foreground">{label}</span>
+      {children}
+      {error && <span className="text-destructive">{error}</span>}
+    </label>
+  );
+}

--- a/frontend/src/app/(portal)/portal/warranty/page.tsx
+++ b/frontend/src/app/(portal)/portal/warranty/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getWarrantyHistory } from "@/services/customers";
+
+export default function WarrantyHistoryPage() {
+  const warrantyQuery = useQuery({
+    queryKey: ["portal", "warranty"],
+    queryFn: getWarrantyHistory,
+  });
+
+  if (warrantyQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading warranty history…</p>;
+  }
+
+  if (warrantyQuery.isError) {
+    return <p className="text-sm text-destructive">Unable to load warranty claims.</p>;
+  }
+
+  const claims = warrantyQuery.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Warranty claims</h1>
+        <p className="text-sm text-muted-foreground">
+          Review your submitted warranty claims and track their progress with our service team.
+        </p>
+      </header>
+
+      {claims.length ? (
+        <ul className="space-y-3">
+          {claims.map((claim) => (
+            <li key={claim.id} className="rounded-md border border-border/60 bg-card/80 p-4 text-sm shadow-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium text-foreground">Claim #{claim.id}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {claim.status} · {claim.createdAt ? new Date(claim.createdAt).toLocaleDateString() : "Pending"}
+                  </p>
+                </div>
+                {claim.invoiceTotal !== null && claim.invoiceTotal !== undefined && (
+                  <span className="text-xs font-medium text-foreground">Invoice total ${claim.invoiceTotal.toFixed(2)}</span>
+                )}
+              </div>
+              {claim.resolutionNotes && (
+                <p className="mt-2 text-xs text-muted-foreground">Resolution: {claim.resolutionNotes}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">You have not submitted any warranty claims.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/customers/[customerId]/page.tsx
+++ b/frontend/src/app/(staff)/customers/[customerId]/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  CustomerInlineProfileForm,
+  VehicleForm,
+  PdfDownloadButton,
+} from "@/components/customers";
+import {
+  Customer,
+  CustomerProfile,
+  Vehicle,
+  getCustomer,
+  getCustomerProfile,
+  getCustomerVehicles,
+} from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export default function CustomerDetailPage() {
+  const params = useParams<{ customerId: string }>();
+  const customerId = params?.customerId;
+  const queryClient = useQueryClient();
+
+  const customerQuery = useQuery<Customer>({
+    queryKey: ["customer", customerId],
+    queryFn: () => getCustomer(customerId!),
+    enabled: Boolean(customerId),
+  });
+
+  const profileQuery = useQuery<CustomerProfile>({
+    queryKey: ["customer", customerId, "profile"],
+    queryFn: () => getCustomerProfile(customerId!),
+    enabled: Boolean(customerId),
+  });
+
+  const vehiclesQuery = useQuery<Vehicle[]>({
+    queryKey: ["customer", customerId, "vehicles"],
+    queryFn: () => getCustomerVehicles(customerId!),
+    enabled: Boolean(customerId),
+  });
+
+  const isLoading = customerQuery.isLoading || profileQuery.isLoading;
+
+  const customer = customerQuery.data;
+  const profile = profileQuery.data;
+  const vehicles = vehiclesQuery.data ?? profile?.vehicles ?? [];
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading profile…</p>;
+  }
+
+  if (customerQuery.isError) {
+    return <p className="text-sm text-destructive">Unable to load customer details.</p>;
+  }
+
+  if (!customer) {
+    return <p className="text-sm text-destructive">Customer not found.</p>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">{customer.fullName}</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage contact information, vehicles, and financial documents for this customer.
+        </p>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[3fr_2fr]">
+        <div className="space-y-6">
+          <div className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Profile</h2>
+            <CustomerInlineProfileForm
+              customerId={customer.id}
+              customer={customer}
+              onCustomerUpdated={(updated) => {
+                queryClient.setQueryData(["customer", customer.id], updated);
+              }}
+            />
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Vehicles</h2>
+            {vehicles.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No vehicles on file.</p>
+            ) : (
+              <ul className="space-y-3">
+                {vehicles.map((vehicle) => (
+                  <li
+                    key={vehicle.id}
+                    className="rounded-md border border-border/60 bg-background/70 p-4 text-sm shadow-sm"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-semibold text-foreground">
+                          {vehicle.year} {vehicle.make} {vehicle.model}
+                        </p>
+                        <p className="text-xs text-muted-foreground">VIN {vehicle.vin}</p>
+                      </div>
+                      <PdfDownloadButton
+                        href={`/vehicles/${vehicle.id}/history/pdf`}
+                        filename={`vehicle-${vehicle.vin}.pdf`}
+                      >
+                        History PDF
+                      </PdfDownloadButton>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <aside className="space-y-6">
+          <div className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Add vehicle</h2>
+            <VehicleForm
+              mode="create"
+              customerId={customer.id}
+              onSuccess={() => {
+                showToast({
+                  title: "Vehicle added",
+                  description: "Vehicle list refreshed",
+                  variant: "success",
+                });
+                vehiclesQuery.refetch();
+              }}
+            />
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Invoices</h2>
+            {profileQuery.isError ? (
+              <p className="text-sm text-destructive">Unable to load invoices.</p>
+            ) : profile?.invoices?.length ? (
+              <ul className="space-y-3">
+                {profile.invoices.map((invoice) => (
+                  <li key={invoice.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium text-foreground">Invoice #{invoice.id}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {invoice.status ?? "PENDING"} · ${invoice.total?.toFixed(2) ?? "0.00"}
+                        </p>
+                      </div>
+                      <PdfDownloadButton href={`/invoices/${invoice.id}/pdf`}>
+                        Download PDF
+                      </PdfDownloadButton>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No invoices available.</p>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-card/80 p-5 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Warranty claims</h2>
+            {profileQuery.isError ? (
+              <p className="text-sm text-destructive">Unable to load warranty claims.</p>
+            ) : profile?.warrantyClaims?.length ? (
+              <ul className="space-y-3">
+                {profile.warrantyClaims.map((claim) => (
+                  <li key={claim.id} className="rounded-md border border-border/60 bg-background/70 p-3 text-sm">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium text-foreground">Claim #{claim.id}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {claim.status} · {claim.createdAt ? new Date(claim.createdAt).toLocaleDateString() : "—"}
+                        </p>
+                      </div>
+                      {claim.workOrderId && (
+                        <Link
+                          href={`/work-orders/${claim.workOrderId}`}
+                          className="inline-flex items-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition hover:bg-accent hover:text-accent-foreground"
+                        >
+                          View work order
+                        </Link>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No warranty claims on file.</p>
+            )}
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/customers/__tests__/customer-search.spec.tsx
+++ b/frontend/src/app/(staff)/customers/__tests__/customer-search.spec.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CustomersPage from "../page";
+import type { Customer } from "@/services/customers";
+
+vi.mock("@/stores/toast-store", () => ({
+  showToast: vi.fn(),
+}));
+
+const searchCustomers = vi.fn();
+const createCustomer = vi.fn();
+const updateCustomer = vi.fn();
+
+vi.mock("@/services/customers", async () => {
+  const actual = await vi.importActual<typeof import("@/services/customers")>("@/services/customers");
+  return {
+    ...actual,
+    searchCustomers: (...args: unknown[]) => searchCustomers(...args),
+    createCustomer: (...args: unknown[]) => createCustomer(...(args as Parameters<typeof createCustomer>)),
+    updateCustomer: (...args: unknown[]) => updateCustomer(...(args as Parameters<typeof updateCustomer>)),
+  };
+});
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = new QueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe("CustomersPage search filters", () => {
+  const customers: Customer[] = [
+    {
+      id: "1",
+      fullName: "Alice Johnson",
+      email: "alice@example.com",
+      phone: "555-0100",
+      street: "123 Main St",
+      city: "Springfield",
+      state: "IL",
+      zip: "62704",
+      visits: 3,
+    },
+    {
+      id: "2",
+      fullName: "Bob Smith",
+      email: "bob@example.com",
+      phone: "555-0200",
+      street: "456 Elm St",
+      city: "Shelbyville",
+      state: "IL",
+      zip: "62565",
+      visits: 1,
+    },
+  ];
+
+  beforeEach(() => {
+    searchCustomers.mockImplementation(async (filters?: { name?: string }) => {
+      if (filters?.name) {
+        const term = filters.name.toLowerCase();
+        return customers.filter((customer) => customer.fullName.toLowerCase().includes(term));
+      }
+      return customers;
+    });
+    createCustomer.mockResolvedValue(customers[0]);
+  });
+
+  it("filters the customer list by name", async () => {
+    renderWithClient(<CustomersPage />);
+
+    expect(await screen.findByText("Alice Johnson")).toBeInTheDocument();
+    expect(screen.getByText("Bob Smith")).toBeInTheDocument();
+
+    const nameInput = screen.getByLabelText("Name");
+    fireEvent.change(nameInput, { target: { value: "Bob" } });
+    fireEvent.submit(nameInput.closest("form") as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(searchCustomers).toHaveBeenLastCalledWith({ name: "Bob", email: "", phone: "" });
+    });
+
+    expect(await screen.findByText("Bob Smith")).toBeInTheDocument();
+    expect(screen.queryByText("Alice Johnson")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(staff)/customers/page.tsx
+++ b/frontend/src/app/(staff)/customers/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { CustomerForm } from "@/components/customers/customer-form";
+import { Customer, CustomerSearchFilters, searchCustomers } from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export default function CustomersPage() {
+  const [filters, setFilters] = useState<CustomerSearchFilters>({
+    name: "",
+    email: "",
+    phone: "",
+  });
+
+  const query = useQuery<Customer[]>({
+    queryKey: ["customers", filters],
+    queryFn: () => searchCustomers(filters),
+    keepPreviousData: true,
+  });
+
+  const updateFilters = useMutation({
+    mutationFn: async (values: CustomerSearchFilters) => values,
+    onSuccess: (values) => {
+      setFilters(values);
+    },
+  });
+
+  const results = useMemo(() => query.data ?? [], [query.data]);
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Customer Directory</h1>
+        <p className="text-sm text-muted-foreground">
+          Search for existing customers, review their contact information, and add new customer records.
+        </p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+        <section className="space-y-6">
+          <SearchForm
+            defaultValues={filters}
+            isSubmitting={updateFilters.isPending}
+            onSubmit={(values) => updateFilters.mutate(values)}
+          />
+
+          <div className="rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+            {query.isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading customers…</p>
+            ) : query.isError ? (
+              <p className="text-sm text-destructive">Unable to load customers.</p>
+            ) : results.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No customers found. Adjust your search filters.</p>
+            ) : (
+              <ul className="space-y-3">
+                {results.map((customer) => (
+                  <CustomerListItem key={customer.id} customer={customer} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        <aside className="rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-foreground">Add a customer</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Capture contact and mailing information for new customers in a single step.
+          </p>
+          <CustomerForm
+            onSuccess={() => {
+              showToast({
+                title: "Customer added",
+                description: "The directory has been refreshed with your new customer.",
+                variant: "success",
+              });
+              query.refetch();
+            }}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+type SearchFormProps = {
+  defaultValues: CustomerSearchFilters;
+  isSubmitting: boolean;
+  onSubmit: (values: CustomerSearchFilters) => void;
+};
+
+function SearchForm({ defaultValues, isSubmitting, onSubmit }: SearchFormProps) {
+  const [localValues, setLocalValues] = useState(defaultValues);
+
+  useEffect(() => {
+    setLocalValues(defaultValues);
+  }, [defaultValues]);
+
+  return (
+    <form
+      className="grid gap-4 rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm md:grid-cols-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit(localValues);
+      }}
+    >
+      <div className="flex flex-col gap-2 text-sm">
+        <label className="font-medium text-foreground" htmlFor="name">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          value={localValues.name ?? ""}
+          onChange={(event) =>
+            setLocalValues((current) => ({ ...current, name: event.target.value }))
+          }
+          placeholder="Search by name"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <label className="font-medium text-foreground" htmlFor="email">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          value={localValues.email ?? ""}
+          onChange={(event) =>
+            setLocalValues((current) => ({ ...current, email: event.target.value }))
+          }
+          placeholder="Search by email"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <label className="font-medium text-foreground" htmlFor="phone">
+          Phone
+        </label>
+        <input
+          id="phone"
+          type="tel"
+          className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          value={localValues.phone ?? ""}
+          onChange={(event) =>
+            setLocalValues((current) => ({ ...current, phone: event.target.value }))
+          }
+          placeholder="Search by phone"
+        />
+      </div>
+
+      <div className="md:col-span-3">
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Applying…" : "Apply filters"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type CustomerListItemProps = {
+  customer: Customer;
+};
+
+function CustomerListItem({ customer }: CustomerListItemProps) {
+  return (
+    <li className="flex flex-col gap-1 rounded-md border border-border/50 bg-background/60 p-4 shadow-sm transition hover:border-primary/60 hover:shadow">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">{customer.fullName}</h3>
+          <p className="text-sm text-muted-foreground">{customer.email}</p>
+        </div>
+        <Link
+          href={`/customers/${customer.id}`}
+          className="inline-flex items-center rounded-md border border-border px-3 py-1 text-sm font-medium text-foreground transition hover:bg-accent hover:text-accent-foreground"
+        >
+          View profile
+        </Link>
+      </div>
+      <dl className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+        <div>
+          <dt className="font-medium text-foreground">Phone</dt>
+          <dd>{customer.phone}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-foreground">Address</dt>
+          <dd>
+            {[customer.street, customer.city, customer.state, customer.zip]
+              .filter(Boolean)
+              .join(", ") || "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-foreground">Visits</dt>
+          <dd>{customer.visits ?? 0}</dd>
+        </div>
+      </dl>
+    </li>
+  );
+}

--- a/frontend/src/components/customers/__tests__/customer-inline-profile-form.spec.tsx
+++ b/frontend/src/components/customers/__tests__/customer-inline-profile-form.spec.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { CustomerInlineProfileForm } from "../customer-inline-profile-form";
+import type { Customer } from "@/services/customers";
+
+const updateCustomer = vi.fn();
+
+vi.mock("@/services/customers", async () => {
+  const actual = await vi.importActual<typeof import("@/services/customers")>("@/services/customers");
+  return {
+    ...actual,
+    updateCustomer: (...args: unknown[]) => updateCustomer(...args),
+  };
+});
+
+vi.mock("@/stores/toast-store", () => ({
+  showToast: vi.fn(),
+}));
+
+function renderForm(customer: Customer) {
+  const queryClient = new QueryClient();
+  const onCustomerUpdated = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CustomerInlineProfileForm
+        customerId={customer.id}
+        customer={customer}
+        onCustomerUpdated={onCustomerUpdated}
+      />
+    </QueryClientProvider>,
+  );
+  return { onCustomerUpdated };
+}
+
+describe("CustomerInlineProfileForm", () => {
+  const customer: Customer = {
+    id: "cust-1",
+    fullName: "Alex Rivers",
+    email: "alex@example.com",
+    phone: "555-0300",
+    street: "789 Oak Ave",
+    city: "Centerville",
+    state: "CA",
+    zip: "90210",
+  };
+
+  it("submits inline profile updates", async () => {
+    const updated: Customer = { ...customer, fullName: "Alexandra Rivers" };
+    updateCustomer.mockResolvedValue(updated);
+
+    const { onCustomerUpdated } = renderForm(customer);
+
+    const nameInput = screen.getByLabelText("Full name");
+    fireEvent.change(nameInput, { target: { value: "Alexandra Rivers" } });
+    fireEvent.click(screen.getByRole("button", { name: /save profile/i }));
+
+    await waitFor(() => {
+      expect(updateCustomer).toHaveBeenCalledWith("cust-1", {
+        fullName: "Alexandra Rivers",
+        email: "alex@example.com",
+        phone: "555-0300",
+        street: "789 Oak Ave",
+        city: "Centerville",
+        state: "CA",
+        zip: "90210",
+      });
+    });
+
+    expect(onCustomerUpdated).toHaveBeenCalledWith(updated);
+    expect(screen.getByDisplayValue("Alexandra Rivers")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/customers/customer-form.tsx
+++ b/frontend/src/components/customers/customer-form.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+
+import {
+  CustomerFormValues,
+  customerCreateSchema,
+  customerUpdateSchema,
+  CustomerUpdateValues,
+} from "@/components/customers/schemas";
+import {
+  Customer,
+  CustomerCreateInput,
+  CustomerUpdateInput,
+  createCustomer,
+  updateCustomer,
+} from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export type CustomerFormMode = "create" | "update";
+
+export type CustomerFormProps = {
+  mode?: CustomerFormMode;
+  customerId?: string;
+  defaultValues?: Partial<CustomerFormValues>;
+  onSuccess?: (customer: Customer) => void;
+};
+
+export function CustomerForm({
+  mode = "create",
+  customerId,
+  defaultValues,
+  onSuccess,
+}: CustomerFormProps) {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const form = useForm<CustomerFormValues | CustomerUpdateValues>({
+    resolver: zodResolver(mode === "create" ? customerCreateSchema : customerUpdateSchema),
+    defaultValues: {
+      fullName: "",
+      email: "",
+      phone: "",
+      street: "",
+      city: "",
+      state: "",
+      zip: "",
+      ...defaultValues,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (values: CustomerFormValues | CustomerUpdateValues) => {
+      const payload: CustomerCreateInput | CustomerUpdateInput = {
+        ...values,
+        street: values.street ?? undefined,
+        city: values.city ?? undefined,
+        state: values.state ?? undefined,
+        zip: values.zip ?? undefined,
+      };
+
+      if (mode === "create") {
+        return createCustomer(payload as CustomerCreateInput);
+      }
+
+      if (!customerId) {
+        throw new Error("Customer ID is required for updates");
+      }
+
+      return updateCustomer(customerId, payload as CustomerUpdateInput);
+    },
+    onSuccess: (customer) => {
+      setServerError(null);
+      showToast({
+        title: mode === "create" ? "Customer created" : "Customer updated",
+        description:
+          mode === "create"
+            ? `Successfully added ${customer.fullName}`
+            : `${customer.fullName}'s profile was updated`,
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: ["customers"] });
+      if (customerId) {
+        queryClient.invalidateQueries({ queryKey: ["customer", customerId] });
+      }
+      onSuccess?.(customer);
+      if (mode === "create") {
+        form.reset();
+      } else {
+        form.reset(customer as CustomerFormValues);
+      }
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to save customer")
+          : "Unable to save customer";
+      setServerError(message);
+      showToast({
+        title: "Save failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await mutation.mutateAsync(values);
+  });
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Full name" error={form.formState.errors.fullName?.message}>
+          <input
+            id="fullName"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("fullName")}
+          />
+        </Field>
+        <Field label="Email" error={form.formState.errors.email?.message}>
+          <input
+            id="email"
+            type="email"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("email")}
+            disabled={mode === "update"}
+          />
+        </Field>
+        <Field label="Phone" error={form.formState.errors.phone?.message}>
+          <input
+            id="phone"
+            type="tel"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("phone")}
+          />
+        </Field>
+        <Field label="Street" error={form.formState.errors.street?.message}>
+          <input
+            id="street"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("street")}
+          />
+        </Field>
+        <Field label="City" error={form.formState.errors.city?.message}>
+          <input
+            id="city"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("city")}
+          />
+        </Field>
+        <Field label="State" error={form.formState.errors.state?.message}>
+          <input
+            id="state"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("state")}
+          />
+        </Field>
+        <Field label="ZIP" error={form.formState.errors.zip?.message}>
+          <input
+            id="zip"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("zip")}
+          />
+        </Field>
+      </div>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        disabled={mutation.isPending}
+      >
+        {mutation.isPending
+          ? mode === "create"
+            ? "Creating…"
+            : "Saving…"
+          : mode === "create"
+            ? "Create customer"
+            : "Save changes"}
+      </button>
+    </form>
+  );
+}
+
+type FieldProps = {
+  label: string;
+  error?: string;
+  children: ReactNode;
+};
+
+function Field({ label, error, children }: FieldProps) {
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-medium text-foreground">{label}</span>
+      {children}
+      {error && <span className="text-destructive">{error}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/customers/customer-inline-profile-form.tsx
+++ b/frontend/src/components/customers/customer-inline-profile-form.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+
+import {
+  CustomerUpdateValues,
+  customerUpdateSchema,
+} from "@/components/customers/schemas";
+import { Customer, updateCustomer } from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export type CustomerInlineProfileFormProps = {
+  customerId: string;
+  customer: Customer;
+  onCustomerUpdated?: (customer: Customer) => void;
+};
+
+export function CustomerInlineProfileForm({
+  customerId,
+  customer,
+  onCustomerUpdated,
+}: CustomerInlineProfileFormProps) {
+  const queryClient = useQueryClient();
+
+  const form = useForm<CustomerUpdateValues>({
+    resolver: zodResolver(customerUpdateSchema),
+    defaultValues: {
+      fullName: customer.fullName,
+      email: customer.email,
+      phone: customer.phone,
+      street: customer.street ?? "",
+      city: customer.city ?? "",
+      state: customer.state ?? "",
+      zip: customer.zip ?? "",
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      fullName: customer.fullName,
+      email: customer.email,
+      phone: customer.phone,
+      street: customer.street ?? "",
+      city: customer.city ?? "",
+      state: customer.state ?? "",
+      zip: customer.zip ?? "",
+    });
+  }, [customer, form]);
+
+  const mutation = useMutation({
+    mutationFn: async (values: CustomerUpdateValues) => {
+      const payload = {
+        ...values,
+        street: values.street?.trim() ? values.street : undefined,
+        city: values.city?.trim() ? values.city : undefined,
+        state: values.state?.trim() ? values.state : undefined,
+        zip: values.zip?.trim() ? values.zip : undefined,
+      };
+      return updateCustomer(customerId, payload);
+    },
+    onSuccess: (updated) => {
+      showToast({
+        title: "Profile updated",
+        description: `${updated.fullName}'s profile is up to date.`,
+        variant: "success",
+      });
+      queryClient.invalidateQueries({ queryKey: ["customer", customerId] });
+      onCustomerUpdated?.(updated);
+      form.reset({
+        fullName: updated.fullName,
+        email: updated.email,
+        phone: updated.phone,
+        street: updated.street ?? "",
+        city: updated.city ?? "",
+        state: updated.state ?? "",
+        zip: updated.zip ?? "",
+      });
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to update profile")
+          : "Unable to update profile";
+      showToast({
+        title: "Update failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await mutation.mutateAsync(values);
+  });
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Full name" error={form.formState.errors.fullName?.message}>
+          <input
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("fullName")}
+          />
+        </Field>
+        <Field label="Email" error={form.formState.errors.email?.message}>
+          <input
+            type="email"
+            disabled
+            className="w-full rounded-md border border-border/70 bg-muted px-3 py-2 text-sm shadow-sm"
+            {...form.register("email")}
+          />
+        </Field>
+        <Field label="Phone" error={form.formState.errors.phone?.message}>
+          <input
+            type="tel"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("phone")}
+          />
+        </Field>
+        <Field label="Street" error={form.formState.errors.street?.message}>
+          <input
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("street")}
+          />
+        </Field>
+        <Field label="City" error={form.formState.errors.city?.message}>
+          <input
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("city")}
+          />
+        </Field>
+        <Field label="State" error={form.formState.errors.state?.message}>
+          <input
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("state")}
+          />
+        </Field>
+        <Field label="ZIP" error={form.formState.errors.zip?.message}>
+          <input
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("zip")}
+          />
+        </Field>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          Changes are saved inline. Edit the fields above and click save.
+        </p>
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "Saving…" : "Save profile"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type FieldProps = {
+  label: string;
+  error?: string;
+  children: ReactNode;
+};
+
+function Field({ label, error, children }: FieldProps) {
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-medium text-foreground">{label}</span>
+      {children}
+      {error && <span className="text-destructive">{error}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/customers/index.ts
+++ b/frontend/src/components/customers/index.ts
@@ -1,0 +1,5 @@
+export * from "./customer-form";
+export * from "./customer-inline-profile-form";
+export * from "./vehicle-form";
+export * from "./pdf-download-button";
+export * from "./schemas";

--- a/frontend/src/components/customers/pdf-download-button.tsx
+++ b/frontend/src/components/customers/pdf-download-button.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { ReactNode, useCallback, useMemo, useState } from "react";
+
+import { showToast } from "@/stores/toast-store";
+
+type PdfDownloadButtonProps = {
+  href: string;
+  filename?: string;
+  children?: ReactNode;
+};
+
+function parseFileName(contentDisposition: string | null, fallback?: string) {
+  if (!contentDisposition) {
+    return fallback ?? "document.pdf";
+  }
+
+  const match = /filename\*=UTF-8''(?<encoded>[^;]+)|filename="?(?<simple>[^";]+)"?/i.exec(contentDisposition);
+  if (!match) {
+    return fallback ?? "document.pdf";
+  }
+
+  if (match.groups?.encoded) {
+    try {
+      return decodeURIComponent(match.groups.encoded);
+    } catch (error) {
+      console.warn("Failed to decode filename", error);
+    }
+  }
+
+  if (match.groups?.simple) {
+    return match.groups.simple;
+  }
+
+  return fallback ?? "document.pdf";
+}
+
+export function PdfDownloadButton({ href, filename, children }: PdfDownloadButtonProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const label = useMemo(() => {
+    if (isDownloading && progress !== null) {
+      return `Downloading… ${progress}%`;
+    }
+    if (isDownloading) {
+      return "Downloading…";
+    }
+    return children ?? "Download PDF";
+  }, [children, isDownloading, progress]);
+
+  const handleDownload = useCallback(async () => {
+    setIsDownloading(true);
+    setProgress(0);
+    setError(null);
+
+    try {
+      const response = await fetch(href, { method: "GET" });
+      if (!response.ok) {
+        throw new Error(`Failed to download (${response.status})`);
+      }
+
+      const lengthHeader = response.headers.get("Content-Length");
+      const total = lengthHeader ? Number.parseInt(lengthHeader, 10) : 0;
+      const resolvedFilename = parseFileName(response.headers.get("Content-Disposition"), filename);
+
+      if (!response.body) {
+        const blob = await response.blob();
+        triggerDownload(blob, resolvedFilename);
+        setProgress(100);
+        setIsDownloading(false);
+        showToast({
+          title: "Download ready",
+          description: `${resolvedFilename} downloaded successfully`,
+          variant: "success",
+        });
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const chunks: Uint8Array[] = [];
+      let received = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          chunks.push(value);
+          received += value.length;
+          if (total > 0) {
+            setProgress(Math.min(100, Math.round((received / total) * 100)));
+          }
+        }
+      }
+
+      const blob = new Blob(chunks, { type: "application/pdf" });
+      triggerDownload(blob, resolvedFilename);
+      setProgress(100);
+      showToast({
+        title: "Download ready",
+        description: `${resolvedFilename} downloaded successfully`,
+        variant: "success",
+      });
+    } catch (downloadError) {
+      console.error(downloadError);
+      const message =
+        downloadError instanceof Error ? downloadError.message : "Unable to download document";
+      setError(message);
+      showToast({
+        title: "Download failed",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [filename, href]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={handleDownload}
+        className="inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        disabled={isDownloading}
+      >
+        {label}
+      </button>
+      {error && <span className="text-xs text-destructive">{error}</span>}
+    </div>
+  );
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const blobUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = blobUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(blobUrl);
+}

--- a/frontend/src/components/customers/schemas.ts
+++ b/frontend/src/components/customers/schemas.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const customerCreateSchema = z.object({
+  fullName: z.string().min(1, "Full name is required"),
+  email: z.string().email("Enter a valid email address"),
+  phone: z.string().min(7, "Phone number is required"),
+  street: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === "" ? undefined : value)),
+  city: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === "" ? undefined : value)),
+  state: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === "" ? undefined : value)),
+  zip: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === "" ? undefined : value)),
+});
+
+export const customerUpdateSchema = customerCreateSchema.partial();
+
+export type CustomerFormValues = z.infer<typeof customerCreateSchema>;
+export type CustomerUpdateValues = z.infer<typeof customerUpdateSchema>;
+
+export const vehicleSchema = z.object({
+  vin: z
+    .string()
+    .min(5, "VIN must be at least 5 characters long")
+    .max(32, "VIN must be shorter than 32 characters"),
+  make: z.string().min(1, "Make is required"),
+  model: z.string().min(1, "Model is required"),
+  year: z
+    .number({ invalid_type_error: "Year must be a number" })
+    .int("Year must be a whole number")
+    .gte(1950, "Year must be 1950 or later")
+    .lte(new Date().getFullYear() + 1, "Year appears to be invalid"),
+});
+
+export const vehicleUpdateSchema = vehicleSchema.partial();
+
+export type VehicleFormValues = z.infer<typeof vehicleSchema>;
+export type VehicleUpdateValues = z.infer<typeof vehicleUpdateSchema>;

--- a/frontend/src/components/customers/vehicle-form.tsx
+++ b/frontend/src/components/customers/vehicle-form.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+
+import {
+  VehicleFormValues,
+  VehicleUpdateValues,
+  vehicleSchema,
+  vehicleUpdateSchema,
+} from "@/components/customers/schemas";
+import {
+  Vehicle,
+  VehicleCreateInput,
+  VehicleUpdateInput,
+  createVehicle,
+  updateVehicle,
+} from "@/services/customers";
+import { showToast } from "@/stores/toast-store";
+
+export type VehicleFormMode = "create" | "update";
+
+export type VehicleFormProps = {
+  mode?: VehicleFormMode;
+  customerId?: string;
+  vehicleId?: string;
+  defaultValues?: Partial<VehicleFormValues>;
+  onSuccess?: (vehicle: Vehicle) => void;
+};
+
+export function VehicleForm({
+  mode = "create",
+  customerId,
+  vehicleId,
+  defaultValues,
+  onSuccess,
+}: VehicleFormProps) {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const form = useForm<VehicleFormValues | VehicleUpdateValues>({
+    resolver: zodResolver(mode === "create" ? vehicleSchema : vehicleUpdateSchema),
+    defaultValues: {
+      vin: "",
+      make: "",
+      model: "",
+      year: new Date().getFullYear(),
+      ...defaultValues,
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (values: VehicleFormValues | VehicleUpdateValues) => {
+      const payload: VehicleCreateInput | VehicleUpdateInput = {
+        ...values,
+      };
+
+      if (mode === "create") {
+        if (!customerId) {
+          throw new Error("Customer ID is required to create vehicles");
+        }
+        return createVehicle(customerId, payload as VehicleCreateInput);
+      }
+
+      if (!vehicleId) {
+        throw new Error("Vehicle ID is required to update vehicles");
+      }
+
+      return updateVehicle(vehicleId, payload as VehicleUpdateInput);
+    },
+    onSuccess: (vehicle) => {
+      showToast({
+        title: mode === "create" ? "Vehicle added" : "Vehicle updated",
+        description:
+          mode === "create"
+            ? `${vehicle.year} ${vehicle.make} ${vehicle.model} is now linked`
+            : `${vehicle.year} ${vehicle.make} ${vehicle.model} saved`,
+        variant: "success",
+      });
+      setServerError(null);
+      if (customerId) {
+        queryClient.invalidateQueries({ queryKey: ["customer", customerId, "vehicles"] });
+      }
+      onSuccess?.(vehicle);
+      if (mode === "create") {
+        form.reset({ vin: "", make: "", model: "", year: new Date().getFullYear() });
+      } else {
+        form.reset(vehicle as VehicleFormValues);
+      }
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to save vehicle")
+          : "Unable to save vehicle";
+      setServerError(message);
+      showToast({
+        title: "Vehicle error",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await mutation.mutateAsync({
+      ...values,
+      year:
+        typeof values.year === "string"
+          ? Number.parseInt(values.year, 10)
+          : values.year,
+    } as VehicleFormValues);
+  });
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="VIN" error={form.formState.errors.vin?.message}>
+          <input
+            id="vin"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("vin")}
+          />
+        </Field>
+        <Field label="Make" error={form.formState.errors.make?.message}>
+          <input
+            id="make"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("make")}
+          />
+        </Field>
+        <Field label="Model" error={form.formState.errors.model?.message}>
+          <input
+            id="model"
+            type="text"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("model")}
+          />
+        </Field>
+        <Field label="Year" error={form.formState.errors.year?.message}>
+          <input
+            id="year"
+            type="number"
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            {...form.register("year", { valueAsNumber: true })}
+          />
+        </Field>
+      </div>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        disabled={mutation.isPending}
+      >
+        {mutation.isPending
+          ? mode === "create"
+            ? "Adding…"
+            : "Saving…"
+          : mode === "create"
+            ? "Add vehicle"
+            : "Save vehicle"}
+      </button>
+    </form>
+  );
+}
+
+type FieldProps = {
+  label: string;
+  error?: string;
+  children: ReactNode;
+};
+
+function Field({ label, error, children }: FieldProps) {
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-medium text-foreground">{label}</span>
+      {children}
+      {error && <span className="text-destructive">{error}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/layout/portal-shell.tsx
+++ b/frontend/src/components/layout/portal-shell.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { ReactNode, useEffect } from "react";
+
+import { useSession } from "@/hooks/use-session";
+import { useLayoutStore } from "@/stores/layout-store";
+
+const navigation = [
+  { label: "Dashboard", href: "/portal/dashboard" },
+  { label: "Profile", href: "/portal/profile" },
+  { label: "Warranty", href: "/portal/warranty" },
+];
+
+type PortalShellProps = {
+  children: ReactNode;
+};
+
+export function PortalShell({ children }: PortalShellProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isSidebarOpen, toggleSidebar, closeSidebar } = useLayoutStore();
+  const { user, isAuthenticated, role, isLoading } = useSession();
+
+  useEffect(() => {
+    if (!isLoading && (!isAuthenticated || role !== "CUSTOMER")) {
+      router.replace("/login");
+    }
+  }, [isAuthenticated, isLoading, role, router]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/90 backdrop-blur">
+        <div className="container flex h-16 items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border text-foreground transition-colors hover:bg-accent lg:hidden"
+              aria-label="Toggle navigation"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+              </svg>
+            </button>
+            <Link href="/portal/dashboard" className="flex items-center gap-2 text-sm font-semibold">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground shadow">CP</span>
+              <span className="hidden sm:inline">Customer Portal</span>
+            </Link>
+          </div>
+          {isAuthenticated && (
+            <div className="hidden flex-col text-xs leading-tight sm:flex">
+              <span className="font-semibold text-foreground">{user?.email}</span>
+              <span className="uppercase tracking-wide text-muted-foreground">{role}</span>
+            </div>
+          )}
+        </div>
+      </header>
+      <div className="flex flex-1">
+        <aside
+          className={`fixed inset-y-0 left-0 z-30 w-60 border-r border-border/60 bg-background/95 px-4 py-6 transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 ${isSidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}
+        >
+          <nav className="space-y-1">
+            {navigation.map((item) => {
+              const isActive = pathname?.startsWith(item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={closeSidebar}
+                  className={`flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    isActive
+                      ? "bg-primary/10 text-primary shadow"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  }`}
+                >
+                  {item.label}
+                  {isActive && <span className="inline-flex h-2 w-2 rounded-full bg-primary" />}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+        {isSidebarOpen && (
+          <button
+            type="button"
+            aria-label="Close sidebar overlay"
+            className="fixed inset-0 z-20 bg-black/40 backdrop-blur-sm lg:hidden"
+            onClick={closeSidebar}
+          />
+        )}
+        <main className="flex-1 bg-gradient-to-b from-background to-background/95">
+          <div className="container py-8">
+            <div className="rounded-xl border border-border/60 bg-card/80 p-6 shadow-sm backdrop-blur">
+              {children}
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/customers.ts
+++ b/frontend/src/services/customers.ts
@@ -1,0 +1,147 @@
+import { get, post, put } from "@/lib/api/client";
+
+export type Customer = {
+  id: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  street?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+  preferredTechnicianId?: string | null;
+  loyaltyPoints?: number;
+  visits?: number;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type Vehicle = {
+  id: string;
+  vin: string;
+  make: string;
+  model: string;
+  year: number;
+  archived?: boolean;
+  createdAt?: string;
+  lastServiceMileage?: number | null;
+};
+
+export type EstimateSummary = {
+  id: string;
+  status?: string | null;
+  total?: number | null;
+  createdAt?: string;
+};
+
+export type InvoiceSummary = {
+  id: string;
+  total?: number | null;
+  status?: string | null;
+  createdAt?: string;
+};
+
+export type WarrantyClaimSummary = {
+  id: string;
+  status: string;
+  workOrderId?: string | null;
+  createdAt?: string;
+  resolutionNotes?: string | null;
+  invoiceTotal?: number | null;
+};
+
+export type AppointmentSummary = {
+  id: string;
+  startTime?: string | null;
+  status?: string | null;
+  serviceType?: string | null;
+};
+
+export type CustomerProfile = {
+  vehicles: Vehicle[];
+  invoices: InvoiceSummary[];
+  warrantyClaims: WarrantyClaimSummary[];
+  appointments: AppointmentSummary[];
+};
+
+export type CustomerSearchFilters = {
+  name?: string;
+  email?: string;
+  phone?: string;
+};
+
+export type CustomerCreateInput = {
+  fullName: string;
+  email: string;
+  phone: string;
+  street?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+};
+
+export type CustomerUpdateInput = Partial<CustomerCreateInput>;
+
+export type VehicleCreateInput = {
+  vin: string;
+  make: string;
+  model: string;
+  year: number;
+};
+
+export type VehicleUpdateInput = Partial<VehicleCreateInput>;
+
+export async function searchCustomers(filters: CustomerSearchFilters = {}) {
+  return get<Customer[]>("/customers", {
+    params: filters,
+  });
+}
+
+export async function getCustomer(customerId: string) {
+  return get<Customer>(`/customers/${customerId}`);
+}
+
+export async function getCustomerProfile(customerId: string) {
+  return get<CustomerProfile>(`/customers/${customerId}/profile`);
+}
+
+export async function createCustomer(input: CustomerCreateInput) {
+  return post<Customer>("/customers", input);
+}
+
+export async function updateCustomer(customerId: string, input: CustomerUpdateInput) {
+  return put<Customer>(`/customers/${customerId}`, input);
+}
+
+export async function createVehicle(customerId: string, input: VehicleCreateInput) {
+  return post<Vehicle>(`/customers/${customerId}/vehicles`, input);
+}
+
+export async function updateVehicle(vehicleId: string, input: VehicleUpdateInput) {
+  return put<Vehicle>(`/vehicles/${vehicleId}`, input);
+}
+
+export async function getCustomerVehicles(customerId: string) {
+  return get<Vehicle[]>(`/customers/${customerId}/vehicles`);
+}
+
+export async function getCustomerDashboard() {
+  return get<{
+    estimates: EstimateSummary[];
+    invoices: InvoiceSummary[];
+    vehicles: Vehicle[];
+    appointments: AppointmentSummary[];
+  }>("/customers/dashboard");
+}
+
+export async function getCustomerSelf() {
+  return get<Customer>("/customers/me");
+}
+
+export async function updateCustomerSelf(input: CustomerUpdateInput) {
+  return put<{ message: string; customer: Customer }>("/customers/me", input);
+}
+
+export async function getWarrantyHistory() {
+  return get<WarrantyClaimSummary[]>("/customers/me/warranty");
+}


### PR DESCRIPTION
## Summary
- add staff customer directory with filtering, profile editing, and PDF export helpers
- introduce shared customer/vehicle form components wired to new customer service client
- build customer portal pages for dashboard, profile management, and warranty history with streaming downloads
- cover search filtering and inline profile updates with component tests

## Testing
- ⚠️ `npm test -- --runInBand` *(fails: npm could not install dependencies in the offline environment due to repeated tarball corruption warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c0d6c0c4832ca95b579f1cf939f8