### PR TITLE
feat: add staff and portal estimate flows

### DIFF
--- a/frontend/src/app/(portal)/portal/estimates/[estimateId]/page.tsx
+++ b/frontend/src/app/(portal)/portal/estimates/[estimateId]/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useEstimate } from "@/hooks/use-estimates";
+import {
+  EstimateItem,
+  EstimateStatus,
+  updateEstimateStatus,
+} from "@/services/estimates";
+import { showToast } from "@/stores/toast-store";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+type PageProps = {
+  params: { estimateId: string };
+};
+
+export default function CustomerEstimateDetailPage({ params }: PageProps) {
+  const queryClient = useQueryClient();
+  const estimateId = params.estimateId;
+  const { data, isLoading, isError } = useEstimate(estimateId);
+  const [signature, setSignature] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const mutateStatus = useMutation({
+    mutationFn: (status: EstimateStatus) => updateEstimateStatus(estimateId, status),
+    onSuccess: ({ estimate }) => {
+      queryClient.invalidateQueries({ queryKey: ["estimates"] });
+      queryClient.invalidateQueries({ queryKey: ["estimates", estimateId] });
+      showToast({
+        title: `Estimate ${estimate.status === "APPROVED" ? "approved" : "updated"}`,
+        description:
+          estimate.status === "APPROVED"
+            ? "Thank you! Our service team will be in touch shortly."
+            : "We have recorded your decision.",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to update estimate",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleApprove = () => {
+    if (!signature.trim()) {
+      showToast({
+        title: "Signature required",
+        description: "Please type your name to provide a digital sign-off.",
+        variant: "destructive",
+      });
+      return;
+    }
+    mutateStatus.mutate("APPROVED");
+  };
+
+  const handleReject = () => {
+    mutateStatus.mutate("REJECTED");
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading estimate…</p>;
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-destructive">We couldn&apos;t find that estimate.</p>
+        <Link href="/portal/estimates" className="text-sm font-medium text-primary hover:underline">
+          Back to estimates
+        </Link>
+      </div>
+    );
+  }
+
+  const disabled = mutateStatus.isPending;
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground">Estimate #{data.id}</h1>
+        <p className="text-sm text-muted-foreground">
+          Current status: <span className="font-medium text-foreground">{formatStatus(data.status)}</span>
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-foreground">Work summary</h2>
+        <div className="overflow-hidden rounded-md border border-border/70 bg-background shadow-sm">
+          <table className="min-w-full divide-y divide-border/70 text-sm">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Description</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Qty</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Part</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">Cost</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/70">
+              {data.items.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-6 text-center text-muted-foreground">
+                    No items recorded on this estimate.
+                  </td>
+                </tr>
+              ) : (
+                data.items.map((item) => <ItemRow key={item.id} item={item} />)
+              )}
+            </tbody>
+            <tfoot className="bg-muted/40">
+              <tr>
+                <td colSpan={3} className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
+                  Total
+                </td>
+                <td className="px-4 py-3 text-right text-lg font-semibold text-foreground">
+                  {formatCurrency(data.total)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </section>
+
+      <section className="space-y-4 rounded-md border border-border/70 bg-muted/30 p-4">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Digital approval</h2>
+          <p className="text-sm text-muted-foreground">
+            To approve, please enter your full name as a digital signature. Your approval authorizes our team to begin the work.
+          </p>
+        </div>
+        <div className="space-y-2 text-sm">
+          <label className="font-medium text-foreground" htmlFor="signature">
+            Signature (type your name)
+          </label>
+          <input
+            id="signature"
+            type="text"
+            value={signature}
+            disabled={disabled}
+            onChange={(event) => setSignature(event.target.value)}
+            className="w-full max-w-md rounded-md border border-border/70 bg-background px-3 py-2 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+        <div className="space-y-2 text-sm">
+          <label className="font-medium text-foreground" htmlFor="notes">
+            Notes (optional)
+          </label>
+          <textarea
+            id="notes"
+            value={notes}
+            disabled={disabled}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={3}
+            className="w-full max-w-md rounded-md border border-border/70 bg-background px-3 py-2 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+            disabled={disabled}
+            onClick={handleApprove}
+          >
+            {mutateStatus.isPending && mutateStatus.variables === "APPROVED"
+              ? "Submitting approval…"
+              : "Approve estimate"}
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border/70 px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted/60 disabled:opacity-50"
+            disabled={disabled}
+            onClick={handleReject}
+          >
+            {mutateStatus.isPending && mutateStatus.variables === "REJECTED"
+              ? "Submitting response…"
+              : "Reject estimate"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ItemRow({ item }: { item: EstimateItem }) {
+  return (
+    <tr className="hover:bg-muted/20">
+      <td className="px-4 py-3 text-foreground">{item.description}</td>
+      <td className="px-4 py-3 text-muted-foreground">{item.qty ?? "—"}</td>
+      <td className="px-4 py-3 text-muted-foreground">{item.partId ?? "—"}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">
+        {formatCurrency(item.cost)}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(portal)/portal/estimates/page.tsx
+++ b/frontend/src/app/(portal)/portal/estimates/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+
+import { useEstimates } from "@/hooks/use-estimates";
+import { EstimateSummary } from "@/services/estimates";
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export default function CustomerEstimatesPage() {
+  const { data, isLoading, isError } = useEstimates();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Your estimates</h1>
+        <p className="text-sm text-muted-foreground">
+          Review pending service proposals and approve work directly from the portal.
+        </p>
+      </header>
+
+      <div className="rounded-md border border-border/70 bg-background shadow-sm">
+        <table className="min-w-full divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Estimate</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/70">
+            {isLoading && (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-center text-muted-foreground">
+                  Loading your estimates…
+                </td>
+              </tr>
+            )}
+            {isError && (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-center text-destructive">
+                  We couldn&apos;t load your estimates. Please refresh the page.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && data && data.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-4 py-6 text-center text-muted-foreground">
+                  No estimates to review right now.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && data?.map((estimate) => (
+              <EstimateRow key={estimate.id} estimate={estimate} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function EstimateRow({ estimate }: { estimate: EstimateSummary }) {
+  return (
+    <tr className="hover:bg-muted/30">
+      <td className="px-4 py-3">
+        <Link href={`/portal/estimates/${estimate.id}`} className="font-semibold text-primary hover:underline">
+          Estimate #{estimate.id}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{formatStatus(estimate.status)}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">
+        {typeof estimate.total === "number"
+          ? new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(estimate.total)
+          : "—"}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(staff)/estimates/[estimateId]/page.tsx
+++ b/frontend/src/app/(staff)/estimates/[estimateId]/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import {
+  useEstimate,
+  useEstimateMutations,
+} from "@/hooks/use-estimates";
+import { EstimateItem } from "@/services/estimates";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+type PageProps = {
+  params: { estimateId: string };
+};
+
+export default function EstimateDetailPage({ params }: PageProps) {
+  const estimateId = params.estimateId;
+  const { data, isLoading, isError } = useEstimate(estimateId);
+  const { statusMutation, approveMutation, rejectMutation, duplicateMutation, applyTemplateMutation } =
+    useEstimateMutations(estimateId);
+  const [templateId, setTemplateId] = useState("");
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading estimate…</p>;
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-destructive">Unable to load estimate details.</p>
+        <Link href="/estimates" className="text-sm font-medium text-primary hover:underline">
+          Back to estimates
+        </Link>
+      </div>
+    );
+  }
+
+  const disableActions =
+    statusMutation.isPending ||
+    approveMutation.isPending ||
+    rejectMutation.isPending ||
+    duplicateMutation.isPending ||
+    applyTemplateMutation.isPending;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Estimate #{data.id}</h1>
+          <p className="text-sm text-muted-foreground">
+            Status: <span className="font-medium text-foreground">{formatStatus(data.status)}</span>
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded-md border border-border/70 px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted/70"
+            disabled={statusMutation.isPending || disableActions}
+            onClick={() => statusMutation.mutate("PENDING_CUSTOMER_APPROVAL")}
+          >
+            Request customer approval
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50"
+            disabled={approveMutation.isPending || disableActions}
+            onClick={() => approveMutation.mutate()}
+          >
+            {approveMutation.isPending ? "Approving…" : "Approve"}
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-red-700 disabled:opacity-50"
+            disabled={rejectMutation.isPending || disableActions}
+            onClick={() => rejectMutation.mutate()}
+          >
+            {rejectMutation.isPending ? "Rejecting…" : "Reject"}
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-border/70 px-3 py-1.5 text-sm font-medium text-foreground transition hover:bg-muted/70"
+            disabled={duplicateMutation.isPending}
+            onClick={() => duplicateMutation.mutate()}
+          >
+            {duplicateMutation.isPending ? "Duplicating…" : "Duplicate"}
+          </button>
+        </div>
+      </div>
+
+      <section className="space-y-4">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Line items</h2>
+            <p className="text-sm text-muted-foreground">
+              Labor and parts captured on this estimate with calculated totals.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={templateId}
+              onChange={(event) => setTemplateId(event.target.value)}
+              placeholder="Template ID"
+              className="w-40 rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+            <button
+              type="button"
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+              disabled={!templateId || applyTemplateMutation.isPending}
+              onClick={() => applyTemplateMutation.mutate(templateId)}
+            >
+              {applyTemplateMutation.isPending ? "Applying…" : "Apply template"}
+            </button>
+          </div>
+        </header>
+
+        <div className="overflow-hidden rounded-md border border-border/70 bg-background shadow-sm">
+          <table className="min-w-full divide-y divide-border/70 text-sm">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Description</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Qty</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Part</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">Cost</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/70">
+              {data.items.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-6 text-center text-muted-foreground">
+                    No items on this estimate yet.
+                  </td>
+                </tr>
+              ) : (
+                data.items.map((item) => <ItemRow key={item.id} item={item} />)
+              )}
+            </tbody>
+            <tfoot className="bg-muted/50">
+              <tr>
+                <td colSpan={3} className="px-4 py-3 text-right text-sm font-medium text-muted-foreground">
+                  Total
+                </td>
+                <td className="px-4 py-3 text-right text-lg font-semibold text-foreground">
+                  {formatCurrency(data.total)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ItemRow({ item }: { item: EstimateItem }) {
+  return (
+    <tr className="hover:bg-muted/40">
+      <td className="px-4 py-3 text-foreground">{item.description}</td>
+      <td className="px-4 py-3 text-muted-foreground">{item.qty ?? "—"}</td>
+      <td className="px-4 py-3 text-muted-foreground">{item.partId ?? "—"}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">
+        {formatCurrency(item.cost)}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(staff)/estimates/new/page.tsx
+++ b/frontend/src/app/(staff)/estimates/new/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { EstimateBuilder } from "@/components/estimates/estimate-builder";
+import { useCreateEstimate } from "@/hooks/use-estimates";
+
+export default function NewEstimatePage() {
+  const router = useRouter();
+  const createEstimate = useCreateEstimate();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">New estimate</h1>
+        <p className="text-sm text-muted-foreground">
+          Build a proposal by combining labor and parts with automatic totals.
+        </p>
+      </header>
+
+      <EstimateBuilder
+        isSubmitting={createEstimate.isPending}
+        onSubmit={async (payload) => {
+          const estimate = await createEstimate.mutateAsync(payload);
+          if (estimate) {
+            router.push(`/estimates/${estimate.id}`);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/estimates/page.tsx
+++ b/frontend/src/app/(staff)/estimates/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import Link from "next/link";
+
+import { useEstimates } from "@/hooks/use-estimates";
+import { EstimateSummary } from "@/services/estimates";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function StatusPill({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    APPROVED: "bg-emerald-100 text-emerald-800",
+    REJECTED: "bg-red-100 text-red-800",
+    PENDING_CUSTOMER_APPROVAL: "bg-amber-100 text-amber-800",
+    DRAFT: "bg-slate-200 text-slate-800",
+  };
+  const classes = map[status] ?? "bg-slate-200 text-slate-800";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${classes}`}>
+      {formatStatus(status)}
+    </span>
+  );
+}
+
+export default function EstimatesPage() {
+  const { data, isLoading, isError } = useEstimates();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Estimates</h1>
+          <p className="text-sm text-muted-foreground">
+            Track drafts awaiting approval and manage customer commitments.
+          </p>
+        </div>
+        <Link
+          href="/estimates/new"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          Create estimate
+        </Link>
+      </div>
+
+      <div className="overflow-hidden rounded-md border border-border/70 bg-background shadow-sm">
+        <table className="min-w-full divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Estimate</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Customer</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Vehicle</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Total</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/70">
+            {isLoading && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                  Loading estimates…
+                </td>
+              </tr>
+            )}
+            {isError && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-destructive">
+                  Unable to load estimates. Try refreshing the page.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && data && data.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                  No estimates yet. Create your first draft to get started.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && data?.map((estimate) => (
+              <EstimateRow key={estimate.id} estimate={estimate} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function EstimateRow({ estimate }: { estimate: EstimateSummary }) {
+  return (
+    <tr className="hover:bg-muted/30">
+      <td className="px-4 py-3">
+        <Link href={`/estimates/${estimate.id}`} className="font-semibold text-primary hover:underline">
+          #{estimate.id}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {estimate.customerName ?? "—"}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {estimate.vehicleLabel ?? "—"}
+      </td>
+      <td className="px-4 py-3">
+        <StatusPill status={estimate.status} />
+      </td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">
+        {formatCurrency(estimate.total ?? null)}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/estimates/estimate-builder.stories.tsx
+++ b/frontend/src/components/estimates/estimate-builder.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { EstimateBuilder } from "@/components/estimates/estimate-builder";
+
+const meta: Meta<typeof EstimateBuilder> = {
+  title: "Estimates/EstimateBuilder",
+  component: EstimateBuilder,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EstimateBuilder>;
+
+export const Empty: Story = {
+  args: {
+    onSubmit: async () => {},
+  },
+};
+
+export const WithDefaults: Story = {
+  render: (args) => (
+    <EstimateBuilder
+      {...args}
+      onSubmit={async () => {}}
+    />
+  ),
+};

--- a/frontend/src/components/estimates/estimate-builder.tsx
+++ b/frontend/src/components/estimates/estimate-builder.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  EstimateCreateInput,
+  EstimateItemDraft,
+  LaborItemDraft,
+  PartItemDraft,
+  calculateEstimateTotals,
+  draftToEstimateItem,
+} from "@/services/estimates";
+
+import { LaborItemEditor, PartItemEditor } from "./estimate-item-editors";
+
+type EstimateBuilderProps = {
+  onSubmit: (payload: EstimateCreateInput) => Promise<void> | void;
+  isSubmitting?: boolean;
+};
+
+export function EstimateBuilder({ onSubmit, isSubmitting }: EstimateBuilderProps) {
+  const [vehicleId, setVehicleId] = useState("");
+  const [labor, setLabor] = useState<LaborItemDraft[]>([]);
+  const [parts, setParts] = useState<PartItemDraft[]>([]);
+
+  const draftItems: EstimateItemDraft[] = useMemo(
+    () => [...labor, ...parts],
+    [labor, parts],
+  );
+
+  const totals = useMemo(() => calculateEstimateTotals(draftItems), [draftItems]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const items = draftItems.map(draftToEstimateItem).filter((item) => item.cost > 0);
+    if (!vehicleId || items.length === 0) {
+      return;
+    }
+    await onSubmit({ vehicle_id: vehicleId, items });
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-foreground" htmlFor="vehicleId">
+          Vehicle ID
+        </label>
+        <input
+          id="vehicleId"
+          type="text"
+          value={vehicleId}
+          onChange={(event) => setVehicleId(event.target.value)}
+          placeholder="Enter the vehicle identifier"
+          className="w-full max-w-sm rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <LaborItemEditor items={labor} onChange={setLabor} />
+
+      <PartItemEditor items={parts} onChange={setParts} />
+
+      <div className="rounded-md border border-border/70 bg-muted/40 p-4">
+        <h3 className="text-sm font-semibold text-foreground">Totals</h3>
+        <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
+          <div className="rounded-md bg-background p-3 shadow-sm">
+            <dt className="text-muted-foreground">Labor</dt>
+            <dd className="text-lg font-semibold text-foreground">
+              ${totals.laborTotal.toFixed(2)}
+            </dd>
+          </div>
+          <div className="rounded-md bg-background p-3 shadow-sm">
+            <dt className="text-muted-foreground">Parts</dt>
+            <dd className="text-lg font-semibold text-foreground">
+              ${totals.partsTotal.toFixed(2)}
+            </dd>
+          </div>
+          <div className="rounded-md bg-background p-3 shadow-sm sm:col-span-3 sm:flex sm:items-center sm:justify-between">
+            <dt className="text-muted-foreground">Grand total</dt>
+            <dd className="text-2xl font-bold text-foreground">
+              ${totals.total.toFixed(2)}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isSubmitting || !vehicleId || draftItems.length === 0}
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isSubmitting ? "Saving…" : "Create estimate"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/estimates/estimate-item-editors.tsx
+++ b/frontend/src/components/estimates/estimate-item-editors.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { ChangeEvent } from "react";
+
+import {
+  EstimateItemDraft,
+  LaborItemDraft,
+  PartItemDraft,
+  calculateDraftCost,
+} from "@/services/estimates";
+
+type LaborItemEditorProps = {
+  items: LaborItemDraft[];
+  onChange: (items: LaborItemDraft[]) => void;
+};
+
+export function LaborItemEditor({ items, onChange }: LaborItemEditorProps) {
+  const handleChange = (
+    index: number,
+    field: keyof Omit<LaborItemDraft, "kind">,
+    value: string,
+  ) => {
+    const next = [...items];
+    const parsed = field === "description" ? value : Number.parseFloat(value) || 0;
+    next[index] = {
+      ...next[index],
+      [field]: field === "description" ? value : parsed,
+    } as LaborItemDraft;
+    onChange(next);
+  };
+
+  const handleAdd = () => {
+    onChange([
+      ...items,
+      { kind: "labor", description: "", hours: 1, rate: 100 },
+    ]);
+  };
+
+  const handleRemove = (index: number) => {
+    const next = items.filter((_, i) => i !== index);
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Labor</h3>
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition hover:bg-primary/90"
+          onClick={handleAdd}
+        >
+          Add labor line
+        </button>
+      </div>
+      <div className="space-y-2">
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No labor added yet. Use the button above to create your first line.
+          </p>
+        ) : (
+          items.map((item, index) => (
+            <LaborRow
+              key={`labor-${index}`}
+              item={item}
+              onChange={(field, value) => handleChange(index, field, value)}
+              onRemove={() => handleRemove(index)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+type LaborRowProps = {
+  item: LaborItemDraft;
+  onChange: (field: keyof Omit<LaborItemDraft, "kind">, value: string) => void;
+  onRemove: () => void;
+};
+
+function LaborRow({ item, onChange, onRemove }: LaborRowProps) {
+  const handleNumberChange = (field: "hours" | "rate") =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(field, event.target.value);
+    };
+
+  return (
+    <div className="rounded-md border border-border/70 p-3 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <label className="flex-1 text-sm">
+          <span className="mb-1 block font-medium text-foreground">Description</span>
+          <input
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.description}
+            onChange={(event) => onChange("description", event.target.value)}
+            placeholder="Describe the labor"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block font-medium text-foreground">Hours</span>
+          <input
+            type="number"
+            min={0}
+            step={0.25}
+            className="w-24 rounded-md border border-border/70 bg-background px-2 py-2 text-sm text-right shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.hours}
+            onChange={handleNumberChange("hours")}
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block font-medium text-foreground">Rate</span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            className="w-24 rounded-md border border-border/70 bg-background px-2 py-2 text-sm text-right shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.rate}
+            onChange={handleNumberChange("rate")}
+          />
+        </label>
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold text-foreground">
+            ${calculateDraftCost(item).toFixed(2)}
+          </span>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="text-xs font-medium text-destructive hover:underline"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type PartItemEditorProps = {
+  items: PartItemDraft[];
+  onChange: (items: PartItemDraft[]) => void;
+};
+
+export function PartItemEditor({ items, onChange }: PartItemEditorProps) {
+  const handleChange = (
+    index: number,
+    field: keyof Omit<PartItemDraft, "kind">,
+    value: string,
+  ) => {
+    const next = [...items];
+    const parsed =
+      field === "description" || field === "partNumber"
+        ? value
+        : Number.parseFloat(value) || 0;
+    next[index] = {
+      ...next[index],
+      [field]: field === "description" || field === "partNumber" ? value : parsed,
+    } as PartItemDraft;
+    onChange(next);
+  };
+
+  const handleAdd = () => {
+    onChange([
+      ...items,
+      { kind: "part", description: "", unitPrice: 0, quantity: 1, partNumber: "" },
+    ]);
+  };
+
+  const handleRemove = (index: number) => {
+    const next = items.filter((_, i) => i !== index);
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Parts</h3>
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition hover:bg-primary/90"
+          onClick={handleAdd}
+        >
+          Add part line
+        </button>
+      </div>
+      <div className="space-y-2">
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No parts selected. Use the button above to add components.
+          </p>
+        ) : (
+          items.map((item, index) => (
+            <PartRow
+              key={`part-${index}`}
+              item={item}
+              onChange={(field, value) => handleChange(index, field, value)}
+              onRemove={() => handleRemove(index)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+type PartRowProps = {
+  item: PartItemDraft;
+  onChange: (field: keyof Omit<PartItemDraft, "kind">, value: string) => void;
+  onRemove: () => void;
+};
+
+function PartRow({ item, onChange, onRemove }: PartRowProps) {
+  const handleNumberChange = (field: "unitPrice" | "quantity") =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(field, event.target.value);
+    };
+
+  return (
+    <div className="rounded-md border border-border/70 p-3 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <label className="flex-1 text-sm">
+          <span className="mb-1 block font-medium text-foreground">Description</span>
+          <input
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.description}
+            onChange={(event) => onChange("description", event.target.value)}
+            placeholder="Describe the part"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block font-medium text-foreground">Part #</span>
+          <input
+            className="w-32 rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.partNumber ?? ""}
+            onChange={(event) => onChange("partNumber", event.target.value)}
+            placeholder="SKU"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block font-medium text-foreground">Qty</span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            className="w-20 rounded-md border border-border/70 bg-background px-2 py-2 text-sm text-right shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.quantity}
+            onChange={handleNumberChange("quantity")}
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block font-medium text-foreground">Unit price</span>
+          <input
+            type="number"
+            min={0}
+            step={0.01}
+            className="w-24 rounded-md border border-border/70 bg-background px-2 py-2 text-sm text-right shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            value={item.unitPrice}
+            onChange={handleNumberChange("unitPrice")}
+          />
+        </label>
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold text-foreground">
+            ${calculateDraftCost(item).toFixed(2)}
+          </span>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="text-xs font-medium text-destructive hover:underline"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function summarizeDrafts(items: EstimateItemDraft[]) {
+  const total = items.reduce((acc, item) => acc + calculateDraftCost(item), 0);
+  return total;
+}

--- a/frontend/src/components/estimates/labor-item-editor.stories.tsx
+++ b/frontend/src/components/estimates/labor-item-editor.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { LaborItemEditor } from "@/components/estimates/estimate-item-editors";
+import { LaborItemDraft } from "@/services/estimates";
+
+const meta: Meta<typeof LaborItemEditor> = {
+  title: "Estimates/LaborItemEditor",
+  component: LaborItemEditor,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LaborItemEditor>;
+
+type WrapperProps = {
+  initial: LaborItemDraft[];
+};
+
+function Wrapper({ initial }: WrapperProps) {
+  const [items, setItems] = useState(initial);
+  return <LaborItemEditor items={items} onChange={setItems} />;
+}
+
+export const Empty: Story = {
+  render: () => <Wrapper initial={[]} />,
+};
+
+export const Prefilled: Story = {
+  render: () => (
+    <Wrapper
+      initial={[
+        { kind: "labor", description: "Initial inspection", hours: 1.5, rate: 110 },
+        { kind: "labor", description: "Brake adjustment", hours: 1, rate: 120 },
+      ]}
+    />
+  ),
+};

--- a/frontend/src/components/estimates/part-item-editor.stories.tsx
+++ b/frontend/src/components/estimates/part-item-editor.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { PartItemEditor } from "@/components/estimates/estimate-item-editors";
+import { PartItemDraft } from "@/services/estimates";
+
+const meta: Meta<typeof PartItemEditor> = {
+  title: "Estimates/PartItemEditor",
+  component: PartItemEditor,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PartItemEditor>;
+
+function Wrapper() {
+  const [items, setItems] = useState<PartItemDraft[]>([
+    {
+      kind: "part",
+      description: "OEM Brake Pad",
+      unitPrice: 65,
+      quantity: 2,
+      partNumber: "BP-01",
+    },
+  ]);
+  return <PartItemEditor items={items} onChange={setItems} />;
+}
+
+export const Default: Story = {
+  render: () => <Wrapper />,
+};
+
+export const Empty: Story = {
+  render: () => {
+    const Component = () => {
+      const [items, setItems] = useState<PartItemDraft[]>([]);
+      return <PartItemEditor items={items} onChange={setItems} />;
+    };
+    return <Component />;
+  },
+};

--- a/frontend/src/hooks/use-estimates.ts
+++ b/frontend/src/hooks/use-estimates.ts
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  EstimateCreateInput,
+  EstimateItemCreate,
+  EstimateStatus,
+  addEstimateItem,
+  applyTemplateToEstimate,
+  approveEstimate,
+  createEstimate,
+  duplicateEstimate,
+  getEstimate,
+  listEstimates,
+  rejectEstimate,
+  updateEstimateStatus,
+} from "@/services/estimates";
+import { showToast } from "@/stores/toast-store";
+
+export function useEstimates() {
+  return useQuery({
+    queryKey: ["estimates"],
+    queryFn: listEstimates,
+  });
+}
+
+export function useEstimate(estimateId: string) {
+  return useQuery({
+    queryKey: ["estimates", estimateId],
+    queryFn: () => getEstimate(estimateId),
+    enabled: Boolean(estimateId),
+  });
+}
+
+export function useCreateEstimate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: EstimateCreateInput) => createEstimate(input),
+    onSuccess: (estimate) => {
+      queryClient.invalidateQueries({ queryKey: ["estimates"] });
+      showToast({
+        title: "Estimate created",
+        description: `Estimate #${estimate.id} drafted`,
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to create estimate",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error", 
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useEstimateMutations(estimateId: string) {
+  const queryClient = useQueryClient();
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["estimates"] });
+    if (estimateId) {
+      queryClient.invalidateQueries({ queryKey: ["estimates", estimateId] });
+    }
+  };
+
+  const makeToast = (title: string, description: string, variant: "success" | "destructive" = "success") => {
+    showToast({ title, description, variant });
+  };
+
+  const statusMutation = useMutation({
+    mutationFn: (status: EstimateStatus) => updateEstimateStatus(estimateId, status),
+    onSuccess: ({ estimate }) => {
+      invalidate();
+      const friendlyStatus = estimate.status
+        .toLowerCase()
+        .replace(/_/g, " ");
+      makeToast("Status updated", `Estimate moved to ${friendlyStatus}`);
+    },
+    onError: (error: unknown) => {
+      makeToast(
+        "Unable to update status",
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message)
+          : "Unexpected error",
+        "destructive",
+      );
+    },
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: () => approveEstimate(estimateId),
+    onSuccess: () => {
+      invalidate();
+      makeToast("Estimate approved", "Customer authorization recorded");
+    },
+    onError: (error: unknown) => {
+      makeToast(
+        "Unable to approve estimate",
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message)
+          : "Unexpected error",
+        "destructive",
+      );
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: () => rejectEstimate(estimateId),
+    onSuccess: () => {
+      invalidate();
+      makeToast("Estimate rejected", "Customer has declined the work");
+    },
+    onError: (error: unknown) => {
+      makeToast(
+        "Unable to reject estimate",
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message)
+          : "Unexpected error",
+        "destructive",
+      );
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: () => duplicateEstimate(estimateId),
+    onSuccess: ({ estimate }) => {
+      invalidate();
+      makeToast("Estimate duplicated", `Draft copy created (#${estimate.id})`);
+    },
+    onError: (error: unknown) => {
+      makeToast(
+        "Unable to duplicate estimate",
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message)
+          : "Unexpected error",
+        "destructive",
+      );
+    },
+  });
+
+  const applyTemplateMutation = useMutation({
+    mutationFn: (templateId: string) => applyTemplateToEstimate(estimateId, templateId),
+    onSuccess: () => {
+      invalidate();
+      makeToast("Template applied", "Service template merged into estimate");
+    },
+    onError: (error: unknown) => {
+      makeToast(
+        "Unable to apply template",
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message)
+          : "Unexpected error",
+        "destructive",
+      );
+    },
+  });
+
+  return {
+    statusMutation,
+    approveMutation,
+    rejectMutation,
+    duplicateMutation,
+    applyTemplateMutation,
+    invalidate,
+  };
+}
+
+export function useAddEstimateItem(estimateId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (item: EstimateItemCreate) => addItem(estimateId, item),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["estimates", estimateId] });
+      showToast({
+        title: "Line item added",
+        description: "The estimate total has been recalculated",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to add line item",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+function addItem(estimateId: string, item: EstimateItemCreate) {
+  return addEstimateItem(estimateId, item);
+}

--- a/frontend/src/services/__tests__/estimates.test.ts
+++ b/frontend/src/services/__tests__/estimates.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EstimateStatus,
+  calculateDraftCost,
+  calculateEstimateTotals,
+  draftToEstimateItem,
+  transitionEstimateStatus,
+} from "@/services/estimates";
+
+describe("estimate draft calculations", () => {
+  it("calculates cost for labor items", () => {
+    const cost = calculateDraftCost({
+      kind: "labor",
+      description: "Brake inspection",
+      hours: 2,
+      rate: 110,
+    });
+
+    expect(cost).toBe(220);
+  });
+
+  it("treats negative values as zero for labor", () => {
+    const cost = calculateDraftCost({
+      kind: "labor",
+      description: "Adjustment",
+      hours: -2,
+      rate: 100,
+    });
+
+    expect(cost).toBe(0);
+  });
+
+  it("calculates cost for part items", () => {
+    const cost = calculateDraftCost({
+      kind: "part",
+      description: "Brake pad set",
+      unitPrice: 45,
+      quantity: 2,
+    });
+
+    expect(cost).toBe(90);
+  });
+
+  it("provides totals grouped by type", () => {
+    const totals = calculateEstimateTotals([
+      {
+        kind: "labor",
+        description: "Diagnostics",
+        hours: 1.5,
+        rate: 120,
+      },
+      {
+        kind: "part",
+        description: "Sensor",
+        unitPrice: 80,
+        quantity: 1,
+      },
+    ]);
+
+    expect(totals).toEqual({ laborTotal: 180, partsTotal: 80, total: 260 });
+  });
+
+  it("produces estimate item payloads from drafts", () => {
+    const laborPayload = draftToEstimateItem({
+      kind: "labor",
+      description: "Alignment",
+      hours: 1,
+      rate: 95,
+    });
+
+    expect(laborPayload).toEqual({
+      description: "Alignment",
+      cost: 95,
+    });
+
+    const partPayload = draftToEstimateItem({
+      kind: "part",
+      description: "Oil filter",
+      unitPrice: 12,
+      quantity: 2,
+      partNumber: "OF-123",
+    });
+
+    expect(partPayload).toEqual({
+      description: "Oil filter",
+      cost: 24,
+      part_id: "OF-123",
+      qty: 2,
+    });
+  });
+});
+
+describe("estimate status transitions", () => {
+  const statuses: EstimateStatus[] = [
+    "DRAFT",
+    "PENDING_CUSTOMER_APPROVAL",
+    "APPROVED",
+    "REJECTED",
+  ];
+
+  it("moves estimates to the appropriate state", () => {
+    expect(transitionEstimateStatus("DRAFT", "approve")).toBe("APPROVED");
+    expect(transitionEstimateStatus("DRAFT", "reject")).toBe("REJECTED");
+    expect(
+      transitionEstimateStatus("DRAFT", "request_customer_approval"),
+    ).toBe("PENDING_CUSTOMER_APPROVAL");
+  });
+
+  it("resets estimates to draft", () => {
+    statuses.forEach((status) => {
+      expect(transitionEstimateStatus(status, "reset")).toBe("DRAFT");
+    });
+  });
+
+  it("returns current state for unknown actions", () => {
+    expect(
+      transitionEstimateStatus("APPROVED", "unknown" as never),
+    ).toBe("APPROVED");
+  });
+});

--- a/frontend/src/services/estimates.ts
+++ b/frontend/src/services/estimates.ts
@@ -1,0 +1,202 @@
+import { get, post, put } from "@/lib/api/client";
+
+export type EstimateStatus =
+  | "DRAFT"
+  | "PENDING_CUSTOMER_APPROVAL"
+  | "APPROVED"
+  | "REJECTED";
+
+export type EstimateItem = {
+  id: string;
+  description: string;
+  cost: number;
+  partId?: string | null;
+  qty?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type Estimate = {
+  id: string;
+  customerId: string;
+  vehicleId: string;
+  status: EstimateStatus;
+  total: number;
+  createdAt: string;
+  updatedAt?: string;
+  expiresAt?: string | null;
+  items: EstimateItem[];
+};
+
+export type EstimateSummary = Pick<Estimate, "id" | "status" | "total" | "createdAt"> & {
+  customerName?: string | null;
+  vehicleLabel?: string | null;
+};
+
+export type EstimateItemCreate = {
+  description: string;
+  cost: number;
+  part_id?: string | null;
+  qty?: number | null;
+};
+
+export type EstimateCreateInput = {
+  vehicle_id: string;
+  items: EstimateItemCreate[];
+};
+
+export type LaborItemDraft = {
+  kind: "labor";
+  description: string;
+  hours: number;
+  rate: number;
+};
+
+export type PartItemDraft = {
+  kind: "part";
+  description: string;
+  unitPrice: number;
+  quantity: number;
+  partNumber?: string;
+};
+
+export type EstimateItemDraft = LaborItemDraft | PartItemDraft;
+
+export type EstimateTotals = {
+  laborTotal: number;
+  partsTotal: number;
+  total: number;
+};
+
+export type EstimateAction =
+  | "request_customer_approval"
+  | "approve"
+  | "reject"
+  | "reset";
+
+export function calculateDraftCost(item: EstimateItemDraft): number {
+  if (item.kind === "labor") {
+    return Number.isFinite(item.hours) && Number.isFinite(item.rate)
+      ? Math.max(0, item.hours) * Math.max(0, item.rate)
+      : 0;
+  }
+
+  return Number.isFinite(item.unitPrice) && Number.isFinite(item.quantity)
+    ? Math.max(0, item.unitPrice) * Math.max(0, item.quantity)
+    : 0;
+}
+
+export function draftToEstimateItem(item: EstimateItemDraft): EstimateItemCreate {
+  if (item.kind === "labor") {
+    return {
+      description: item.description,
+      cost: calculateDraftCost(item),
+    };
+  }
+
+  return {
+    description: item.description,
+    cost: calculateDraftCost(item),
+    part_id: item.partNumber?.trim() ? item.partNumber.trim() : undefined,
+    qty: item.quantity,
+  };
+}
+
+export function calculateEstimateTotals(items: EstimateItemDraft[]): EstimateTotals {
+  return items.reduce<EstimateTotals>(
+    (totals, item) => {
+      const cost = calculateDraftCost(item);
+      if (item.kind === "labor") {
+        const laborTotal = totals.laborTotal + cost;
+        return {
+          laborTotal,
+          partsTotal: totals.partsTotal,
+          total: laborTotal + totals.partsTotal,
+        };
+      }
+
+      const partsTotal = totals.partsTotal + cost;
+      return {
+        laborTotal: totals.laborTotal,
+        partsTotal,
+        total: totals.laborTotal + partsTotal,
+      };
+    },
+    { laborTotal: 0, partsTotal: 0, total: 0 },
+  );
+}
+
+export function transitionEstimateStatus(
+  current: EstimateStatus,
+  action: EstimateAction,
+): EstimateStatus {
+  switch (action) {
+    case "approve":
+      return "APPROVED";
+    case "reject":
+      return "REJECTED";
+    case "request_customer_approval":
+      return "PENDING_CUSTOMER_APPROVAL";
+    case "reset":
+      return "DRAFT";
+    default:
+      return current;
+  }
+}
+
+export async function listEstimates() {
+  return get<EstimateSummary[]>("/estimates");
+}
+
+export async function getEstimate(estimateId: string) {
+  return get<Estimate>(`/estimates/${estimateId}`);
+}
+
+export async function createEstimate(input: EstimateCreateInput) {
+  return post<Estimate>("/estimates", input);
+}
+
+export async function addEstimateItem(
+  estimateId: string,
+  item: EstimateItemCreate,
+) {
+  return post<EstimateItem>(`/estimates/${estimateId}/items`, item);
+}
+
+export async function updateEstimateStatus(
+  estimateId: string,
+  status: EstimateStatus,
+) {
+  return put<{ message: string; estimate: Estimate }>(
+    `/estimates/${estimateId}/status`,
+    undefined,
+    { params: { status } },
+  );
+}
+
+export async function approveEstimate(estimateId: string) {
+  return put<{ message: string; estimate: Estimate }>(
+    `/estimates/${estimateId}/approve`,
+  );
+}
+
+export async function rejectEstimate(estimateId: string) {
+  return put<{ message: string; estimate: Estimate }>(
+    `/estimates/${estimateId}/reject`,
+  );
+}
+
+export async function duplicateEstimate(estimateId: string) {
+  return post<{ message: string; estimate: Estimate }>(
+    `/estimates/${estimateId}/duplicate`,
+  );
+}
+
+export async function applyTemplateToEstimate(
+  estimateId: string,
+  templateId: string,
+) {
+  return post<{ message: string }>(
+    `/estimates/${estimateId}/apply-template/${templateId}`,
+  );
+}


### PR DESCRIPTION
## Summary
- add staff estimate listing, creation, and detail experiences wired to React Query actions
- implement reusable estimate builder and item editors with Storybook coverage
- introduce estimate services, hooks, and unit tests for totals and status transitions alongside portal approval flows

## Testing
- npm run test -- --runInBand *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74755bf60832cb4fb1821477798d0