### PR TITLE
Add invoice management surfaces and analytics

### DIFF
--- a/backend/tests/test_invoice_routes.py
+++ b/backend/tests/test_invoice_routes.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.invoice import routes
+
+
+@dataclass
+class FakeRecord:
+    data: Dict[str, Any]
+
+    def copy(self) -> Dict[str, Any]:
+        return dict(self.data)
+
+
+class FakeCustomerTable:
+    def __init__(self) -> None:
+        self.records: Dict[str, Dict[str, Any]] = {}
+
+    def add(self, customer: Dict[str, Any]) -> None:
+        self.records[customer["id"]] = dict(customer)
+
+    def get(self, customer_id: str | None) -> Dict[str, Any] | None:
+        if not customer_id:
+            return None
+        record = self.records.get(customer_id)
+        return dict(record) if record else None
+
+
+class FakePaymentTable:
+    def __init__(self, db: "FakeDB") -> None:
+        self._db = db
+        self.records: List[Dict[str, Any]] = []
+
+    async def create(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        record = {"id": f"pay-{len(self.records) + 1}", **data}
+        self.records.append(record)
+        return dict(record)
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:
+        if not where:
+            return [dict(record) for record in self.records]
+        invoice_id = where.get("invoiceId")
+        return [dict(record) for record in self.records if record.get("invoiceId") == invoice_id]
+
+
+class FakeInvoiceTable:
+    def __init__(self, db: "FakeDB") -> None:
+        self._db = db
+        self.records: Dict[str, Dict[str, Any]] = {}
+        self.updated: List[Dict[str, Any]] = []
+
+    async def find_many(self, where: Dict[str, Any] | None = None, include: Dict[str, Any] | None = None, order_by: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:  # noqa: ANN001
+        invoices = list(self.records.values())
+        if where:
+            for key, value in where.items():
+                invoices = [record for record in invoices if record.get(key) == value]
+        if order_by and "createdAt" in order_by:
+            invoices.sort(key=lambda record: record.get("createdAt"), reverse=order_by["createdAt"] == "desc")
+        if order_by and "finalizedAt" in order_by:
+            invoices.sort(key=lambda record: record.get("finalizedAt"), reverse=order_by["finalizedAt"] == "desc")
+        return [self._apply_include(record, include) for record in invoices]
+
+    async def find_unique(self, where: Dict[str, Any], include: Dict[str, Any] | None = None) -> Dict[str, Any] | None:
+        record = self.records.get(where.get("id"))
+        if not record:
+            return None
+        return self._apply_include(record, include)
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        record = self.records.get(where.get("id"))
+        if not record:
+            raise KeyError("Invoice not found")
+        record.update(data)
+        self.updated.append({"where": where, "data": data})
+        return self._apply_include(record, None)
+
+    def _apply_include(self, record: Dict[str, Any], include: Dict[str, Any] | None) -> Dict[str, Any]:
+        result = dict(record)
+        if include and include.get("payments"):
+            result["payments"] = [
+                dict(payment) for payment in self._db.payment.records if payment.get("invoiceId") == record.get("id")
+            ]
+        if include and include.get("items"):
+            result["items"] = [dict(item) for item in record.get("items", [])]
+        if include and include.get("customer"):
+            customer = self._db.customer.get(record.get("customerId"))
+            if customer:
+                result["customer"] = customer
+        return result
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.connected = False
+        self.invoice = FakeInvoiceTable(self)
+        self.payment = FakePaymentTable(self)
+        self.customer = FakeCustomerTable()
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+@pytest.fixture()
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    fake_db = FakeDB()
+    monkeypatch.setattr(routes, "db", fake_db)
+
+    api = FastAPI()
+    api.include_router(routes.router)
+    return api
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    test_client = TestClient(app)
+    test_client.app.dependency_overrides[routes.get_current_user] = lambda: SimpleNamespace(id="manager-1", role="MANAGER")
+    return test_client
+
+
+def seed_invoice(fake_db: FakeDB, invoice_id: str = "inv-1", *, total: float = 200.0, late_fee: float = 0.0) -> None:
+    fake_db.customer.add({"id": "cust-1", "name": "Jamie Customer", "email": "jamie@example.com"})
+    fake_db.invoice.records[invoice_id] = {
+        "id": invoice_id,
+        "number": invoice_id,
+        "customerId": "cust-1",
+        "status": "DRAFT",
+        "total": total,
+        "lateFee": late_fee,
+        "createdAt": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "dueDate": datetime(2024, 1, 15, tzinfo=timezone.utc).isoformat(),
+        "issuedDate": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        "items": [
+            {"id": "item-1", "description": "Brake pads", "quantity": 1, "unitPrice": total / 2, "cost": total / 4},
+            {"id": "item-2", "description": "Labor", "quantity": 1, "unitPrice": total / 2, "cost": total / 3},
+        ],
+        "customer": {"id": "cust-1", "name": "Jamie Customer", "email": "jamie@example.com"},
+        "finalizedAt": datetime(2024, 1, 2, tzinfo=timezone.utc),
+    }
+
+
+def get_fake_db() -> FakeDB:
+    assert isinstance(routes.db, FakeDB)
+    return routes.db
+
+
+def test_manual_payment_transitions_invoice_status(client: TestClient) -> None:
+    fake_db = get_fake_db()
+    seed_invoice(fake_db)
+
+    response = client.post("/invoice/inv-1/pay", json={"amount": 100, "method": "CASH"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "PARTIALLY_PAID"
+    assert body["payments"][-1]["runningBalance"] == 100
+
+    response = client.post("/invoice/inv-1/pay", json={"amount": 100, "method": "CARD"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "PAID"
+    assert body["balanceDue"] == 0
+
+
+def test_finalize_invoice_marks_finalized(client: TestClient) -> None:
+    fake_db = get_fake_db()
+    seed_invoice(fake_db)
+
+    response = client.post("/invoice/inv-1/finalize")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "FINALIZED"
+    assert fake_db.invoice.records["inv-1"]["status"] == "FINALIZED"
+
+
+def test_margin_endpoint_uses_line_items(client: TestClient) -> None:
+    fake_db = get_fake_db()
+    seed_invoice(fake_db, total=300.0)
+
+    response = client.get("/invoice/inv-1/margin")
+    assert response.status_code == 200
+    body = response.json()
+    assert pytest.approx(body["total_price"], rel=1e-3) == 300.0
+    assert body["gross_margin_percent"] > 0
+
+
+def test_margin_analytics_aggregates_finalized_invoices(client: TestClient) -> None:
+    fake_db = get_fake_db()
+    seed_invoice(fake_db, invoice_id="inv-1", total=300.0)
+    fake_db.invoice.records["inv-1"]["status"] = "FINALIZED"
+    seed_invoice(fake_db, invoice_id="inv-2", total=150.0)
+    fake_db.invoice.records["inv-2"]["status"] = "FINALIZED"
+
+    response = client.get("/invoice/analytics/margin")
+    assert response.status_code == 200
+    analytics = response.json()
+    assert analytics["lowMarginInvoices"] >= 0
+    assert len(analytics["series"]) == 2
+
+
+def test_stripe_checkout_mocked(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    fake_db = get_fake_db()
+    seed_invoice(fake_db, total=120.0)
+
+    captured: Dict[str, Any] = {}
+
+    class FakeSession:
+        url = "https://stripe.test/session"
+
+    def fake_create(**kwargs: Any) -> FakeSession:
+        captured.update(kwargs)
+        return FakeSession()
+
+    monkeypatch.setattr(routes.stripe.checkout.Session, "create", fake_create)  # type: ignore[attr-defined]
+    client.app.dependency_overrides[routes.get_current_user] = lambda: SimpleNamespace(id="cust-1", role="CUSTOMER")
+
+    response = client.post("/invoice/inv-1/pay/online")
+    assert response.status_code == 200
+    assert response.json()["checkout_url"] == "https://stripe.test/session"
+    assert captured["metadata"]["invoice_id"] == "inv-1"
+    assert captured["line_items"][0]["price_data"]["unit_amount"] == 12000

--- a/frontend/src/app/(portal)/portal/invoices/[invoiceId]/page.tsx
+++ b/frontend/src/app/(portal)/portal/invoices/[invoiceId]/page.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { useInvoice, useStripeCheckout } from "@/hooks/use-invoices";
+import { downloadInvoicePdf } from "@/services/invoices";
+import type { InvoiceLineItem, InvoicePayment } from "@/services/invoices";
+import { showToast } from "@/stores/toast-store";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export default function PortalInvoiceDetailPage() {
+  const params = useParams<{ invoiceId: string }>();
+  const invoiceId = Array.isArray(params?.invoiceId) ? params?.invoiceId[0] : params?.invoiceId;
+  const { data: invoice, isLoading } = useInvoice(invoiceId ?? "");
+  const checkoutMutation = useStripeCheckout(invoiceId ?? "");
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    if (!invoiceId || !invoice) {
+      return;
+    }
+    try {
+      setIsDownloading(true);
+      const blob = await downloadInvoicePdf(invoiceId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `invoice-${invoice.number}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      showToast({
+        title: "Unable to download invoice",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  if (!invoiceId) {
+    return (
+      <div className="space-y-2 text-sm text-destructive">
+        <p>Invoice id missing from URL.</p>
+        <Link href="/portal/invoices" className="text-primary underline">
+          Back to invoices
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <Link href="/portal/invoices" className="text-xs text-muted-foreground hover:text-foreground">
+            ← Back to invoices
+          </Link>
+          <h1 className="text-2xl font-semibold text-foreground">Invoice #{invoice?.number ?? invoiceId}</h1>
+          <p className="text-sm text-muted-foreground">
+            {invoice ? formatStatus(invoice.status) : "Loading status"} • Due {formatDate(invoice?.dueDate ?? null)}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="inline-flex items-center justify-center rounded-md border border-border/60 px-4 py-2 text-sm font-medium text-foreground transition hover:bg-accent"
+            disabled={isDownloading || isLoading}
+          >
+            {isDownloading ? "Preparing…" : "Download PDF"}
+          </button>
+          <button
+            type="button"
+            onClick={() => invoiceId && checkoutMutation.mutate()}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition hover:bg-primary/90"
+            disabled={!invoiceId || checkoutMutation.isPending || isLoading}
+          >
+            {checkoutMutation.isPending ? "Redirecting…" : "Pay online"}
+          </button>
+        </div>
+      </header>
+
+      {isLoading || !invoice ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="h-36 animate-pulse rounded-lg bg-muted/40" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <section className="rounded-lg border border-border/60 p-4">
+            <h2 className="text-lg font-semibold text-foreground">Summary</h2>
+            <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Issued</dt>
+                <dd className="font-medium text-foreground">{formatDate(invoice.issuedDate)}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Due</dt>
+                <dd className="font-medium text-foreground">{formatDate(invoice.dueDate)}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Total</dt>
+                <dd className="font-semibold text-foreground">{formatCurrency(invoice.total)}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Balance</dt>
+                <dd className="font-semibold text-foreground">{formatCurrency(invoice.balanceDue)}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">Line items</h2>
+            <div className="mt-3 overflow-hidden rounded-lg border border-border/60">
+              <table className="min-w-full divide-y divide-border/70 text-sm">
+                <thead className="bg-muted/40">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-muted-foreground">Description</th>
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Qty</th>
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Unit price</th>
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Line total</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {invoice.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-4 text-center text-muted-foreground">
+                        No line items recorded.
+                      </td>
+                    </tr>
+                  ) : (
+                    invoice.items.map((item) => <LineItemRow key={item.id} item={item} />)
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-foreground">Payments</h2>
+            <div className="mt-3 overflow-hidden rounded-lg border border-border/60">
+              <table className="min-w-full divide-y divide-border/70 text-sm">
+                <thead className="bg-muted/40">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-medium text-muted-foreground">Received</th>
+                    <th className="px-4 py-2 text-left font-medium text-muted-foreground">Method</th>
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Amount</th>
+                    <th className="px-4 py-2 text-right font-medium text-muted-foreground">Remaining</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {invoice.payments.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-4 text-center text-muted-foreground">
+                        No payments recorded yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    invoice.payments.map((payment) => <PaymentRow key={payment.id} payment={payment} />)
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LineItemRow({ item }: { item: InvoiceLineItem }) {
+  return (
+    <tr>
+      <td className="px-4 py-2 text-foreground">{item.description ?? "Line item"}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">{item.quantity}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">{formatCurrency(item.unitPrice)}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">
+        {formatCurrency(item.unitPrice * item.quantity)}
+      </td>
+    </tr>
+  );
+}
+
+function PaymentRow({ payment }: { payment: InvoicePayment }) {
+  return (
+    <tr>
+      <td className="px-4 py-2 text-muted-foreground">{formatDate(payment.receivedAt)}</td>
+      <td className="px-4 py-2 text-muted-foreground">{payment.method}</td>
+      <td className="px-4 py-2 text-right text-foreground">{formatCurrency(payment.amount)}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">
+        {typeof payment.runningBalance === "number" ? formatCurrency(payment.runningBalance) : "—"}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(portal)/portal/invoices/page.tsx
+++ b/frontend/src/app/(portal)/portal/invoices/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { useInvoices, useStripeCheckout } from "@/hooks/use-invoices";
+import { downloadInvoicePdf } from "@/services/invoices";
+import type { InvoiceSummary } from "@/services/invoices";
+import { showToast } from "@/stores/toast-store";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export default function PortalInvoicesPage() {
+  const { data: invoices, isLoading, isError } = useInvoices();
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const handleDownload = async (invoiceId: string, invoiceNumber: string) => {
+    try {
+      setDownloadingId(invoiceId);
+      const blob = await downloadInvoicePdf(invoiceId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `invoice-${invoiceNumber}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      showToast({
+        title: "Unable to download invoice",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground">My invoices</h1>
+        <p className="text-sm text-muted-foreground">
+          Review open balances, download statements, and pay securely online.
+        </p>
+      </header>
+
+      <div className="overflow-hidden rounded-md border border-border/70 bg-background shadow-sm">
+        <table className="min-w-full divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Invoice</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Issued</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Due</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Total</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Balance</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/70">
+            {isLoading && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                  Loading invoices…
+                </td>
+              </tr>
+            )}
+            {isError && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-destructive">
+                  Unable to load invoices. Please try again later.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && invoices && invoices.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                  You have no invoices yet.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError &&
+              invoices?.map((invoice) => (
+                <InvoiceRow
+                  key={invoice.id}
+                  invoice={invoice}
+                  isDownloading={downloadingId === invoice.id}
+                  onDownload={() => handleDownload(invoice.id, invoice.number)}
+                />
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+type InvoiceRowProps = {
+  invoice: InvoiceSummary;
+  isDownloading: boolean;
+  onDownload: () => void;
+};
+
+function InvoiceRow({ invoice, isDownloading, onDownload }: InvoiceRowProps) {
+  const checkoutMutation = useStripeCheckout(invoice.id);
+
+  return (
+    <tr className="hover:bg-muted/30">
+      <td className="px-4 py-3">
+        <Link href={`/portal/invoices/${invoice.id}`} className="font-semibold text-primary hover:underline">
+          #{invoice.number}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.issuedDate)}</td>
+      <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.dueDate)}</td>
+      <td className="px-4 py-3 text-muted-foreground">{formatStatus(invoice.status)}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">{formatCurrency(invoice.total)}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">{formatCurrency(invoice.balanceDue)}</td>
+      <td className="px-4 py-3 text-right">
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onDownload}
+            className="inline-flex items-center rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-accent"
+            disabled={isDownloading}
+          >
+            {isDownloading ? "Preparing…" : "Download"}
+          </button>
+          <button
+            type="button"
+            onClick={() => checkoutMutation.mutate()}
+            className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow transition hover:bg-primary/90"
+            disabled={checkoutMutation.isPending}
+          >
+            {checkoutMutation.isPending ? "Redirecting…" : "Pay online"}
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
+++ b/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
@@ -6,6 +6,7 @@ import { LowStockPartsTable } from "@/components/dashboard/low-stock-parts-table
 import { OverdueInvoicesTable } from "@/components/dashboard/overdue-invoices-table";
 import { SummaryFilters, type TechnicianOption } from "@/components/dashboard/summary-filters";
 import { SummaryGrid } from "@/components/dashboard/summary-grid";
+import { InvoiceMarginInsights } from "@/components/dashboard/invoice-margin-insights";
 import {
   useAdminSummary,
   useLowStockParts,
@@ -13,6 +14,7 @@ import {
   useSummaryCsv,
   useTechnicianOptions,
 } from "@/hooks/use-dashboard-data";
+import { useInvoiceMarginAnalytics } from "@/hooks/use-invoices";
 import type { AdminSummaryFilters } from "@/services/dashboard";
 
 function downloadCsv(content: string, fileName: string) {
@@ -31,6 +33,7 @@ export function ManagerDashboardView() {
   const { data: technicians } = useTechnicianOptions();
   const { data: overdueInvoices } = useOverdueInvoices();
   const { data: lowStockParts } = useLowStockParts();
+  const { data: invoiceMargins, isLoading: isMarginsLoading } = useInvoiceMarginAnalytics();
   const csv = useSummaryCsv(metrics ?? [], filters);
 
   const technicianOptions: TechnicianOption[] = useMemo(
@@ -68,6 +71,15 @@ export function ManagerDashboardView() {
       ) : (
         <SummaryGrid metrics={metrics} />
       )}
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Invoice margin analytics</h2>
+          <p className="text-xs text-muted-foreground">
+            Track profitability signals and focus coaching on low margin jobs.
+          </p>
+        </div>
+        <InvoiceMarginInsights analytics={invoiceMargins} isLoading={isMarginsLoading} />
+      </section>
       <div className="grid gap-6 lg:grid-cols-2">
         <OverdueInvoicesTable invoices={overdueInvoices ?? []} />
         <LowStockPartsTable parts={lowStockParts ?? []} />

--- a/frontend/src/app/(staff)/invoices/[invoiceId]/page.tsx
+++ b/frontend/src/app/(staff)/invoices/[invoiceId]/page.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { useFinalizeInvoice, useInvoice, useInvoiceMargin, useManualPayment } from "@/hooks/use-invoices";
+import type { InvoiceLineItem, InvoicePayment } from "@/services/invoices";
+
+const paymentMethods = ["CASH", "CHECK", "CARD", "BANK_TRANSFER", "LOYALTY"];
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export default function InvoiceDetailPage() {
+  const params = useParams<{ invoiceId: string }>();
+  const invoiceId = Array.isArray(params?.invoiceId) ? params?.invoiceId[0] : params?.invoiceId;
+  const { data: invoice, isLoading } = useInvoice(invoiceId ?? "");
+  const { data: margin } = useInvoiceMargin(invoiceId ?? "");
+  const finalizeMutation = useFinalizeInvoice(invoiceId ?? "");
+  const paymentMutation = useManualPayment(invoiceId ?? "");
+
+  const [amount, setAmount] = useState("");
+  const [method, setMethod] = useState(paymentMethods[0]);
+
+  const outstandingBalance = useMemo(() => formatCurrency(invoice?.balanceDue ?? null), [invoice?.balanceDue]);
+
+  if (!invoiceId) {
+    return (
+      <div className="space-y-2 text-sm text-destructive">
+        <p>Invoice id missing from the route.</p>
+        <Link href="/invoices" className="text-primary underline">
+          Back to invoices
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <Link href="/invoices" className="text-xs text-muted-foreground hover:text-foreground">
+            ← Back to invoices
+          </Link>
+          <h1 className="text-2xl font-semibold text-foreground">Invoice #{invoice?.number ?? invoiceId}</h1>
+          <p className="text-sm text-muted-foreground">
+            {invoice?.customer?.name ?? "Unassigned"} • Status {invoice ? formatStatus(invoice.status) : "Loading"}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => finalizeMutation.mutate()}
+          disabled={finalizeMutation.isPending || invoice?.status === "FINALIZED"}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted"
+        >
+          {finalizeMutation.isPending ? "Finalizing…" : invoice?.status === "FINALIZED" ? "Finalized" : "Finalize invoice"}
+        </button>
+      </header>
+
+      {isLoading || !invoice ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="h-40 animate-pulse rounded-xl bg-muted/40" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <section className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <DataCard label="Issued" value={formatDate(invoice.issuedDate)} />
+              <DataCard label="Due" value={formatDate(invoice.dueDate)} />
+              <DataCard label="Outstanding" value={outstandingBalance} highlight />
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Line items</h2>
+              <div className="mt-3 overflow-hidden rounded-md border border-border/60">
+                <table className="min-w-full divide-y divide-border/70 text-sm">
+                  <thead className="bg-muted/40">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">Description</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">Qty</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">Unit Price</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/70">
+                    {invoice.items.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-4 text-center text-muted-foreground">
+                          No items on this invoice.
+                        </td>
+                      </tr>
+                    ) : (
+                      invoice.items.map((item) => <LineItemRow key={item.id} item={item} />)
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-md border border-border/60 p-4">
+                <h3 className="text-sm font-semibold text-foreground">Totals</h3>
+                <dl className="mt-3 space-y-2 text-sm">
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Subtotal</dt>
+                    <dd className="font-medium text-foreground">{formatCurrency(invoice.subtotal)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Tax</dt>
+                    <dd className="font-medium text-foreground">{formatCurrency(invoice.tax)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Discounts</dt>
+                    <dd className="font-medium text-foreground">{formatCurrency(invoice.discountTotal)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Late fee</dt>
+                    <dd className="font-medium text-foreground">{formatCurrency(invoice.lateFee)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between border-t border-dashed border-border/60 pt-2">
+                    <dt className="text-sm font-semibold text-foreground">Total due</dt>
+                    <dd className="text-base font-semibold text-foreground">{formatCurrency(invoice.total + invoice.lateFee)}</dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div className="rounded-md border border-border/60 p-4">
+                <h3 className="text-sm font-semibold text-foreground">Loyalty summary</h3>
+                <dl className="mt-3 space-y-2 text-sm">
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Points earned</dt>
+                    <dd className="font-medium text-foreground">{invoice.loyalty.pointsEarned}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Customer balance</dt>
+                    <dd className="font-medium text-foreground">{invoice.loyalty.customerBalance}</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Payments</h2>
+              <div className="mt-3 overflow-hidden rounded-md border border-border/60">
+                <table className="min-w-full divide-y divide-border/70 text-sm">
+                  <thead className="bg-muted/40">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">Received</th>
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">Method</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">Amount</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">Balance</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/70">
+                    {invoice.payments.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-4 text-center text-muted-foreground">
+                          No payments recorded yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      invoice.payments.map((payment) => <PaymentRow key={payment.id} payment={payment} />)
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          <aside className="space-y-6">
+            <div className="rounded-md border border-border/60 p-4">
+              <h2 className="text-lg font-semibold text-foreground">Margin analysis</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Gross margin calculated from itemized costs. Threshold {margin?.threshold ?? "—"}%.
+              </p>
+              <div className="mt-4 space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Parts & labor cost</span>
+                  <span className="font-medium text-foreground">{formatCurrency(margin?.total_cost ?? null)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Billed amount</span>
+                  <span className="font-medium text-foreground">{formatCurrency(margin?.total_price ?? null)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Gross margin</span>
+                  <span
+                    className={`font-semibold ${
+                      margin?.is_below_threshold ? "text-red-600" : "text-emerald-600"
+                    }`}
+                  >
+                    {typeof margin?.gross_margin_percent === "number"
+                      ? `${margin.gross_margin_percent.toFixed(2)}%`
+                      : "—"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-border/60 p-4">
+              <h2 className="text-lg font-semibold text-foreground">Record payment</h2>
+              <form
+                className="mt-4 space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  const amountValue = Number.parseFloat(amount);
+                  if (Number.isNaN(amountValue) || amountValue <= 0) {
+                    return;
+                  }
+                  paymentMutation.mutate({ amount: amountValue, method });
+                  setAmount("");
+                }}
+              >
+                <div className="space-y-1">
+                  <label htmlFor="amount" className="text-xs font-medium uppercase text-muted-foreground">
+                    Amount
+                  </label>
+                  <input
+                    id="amount"
+                    name="amount"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={amount}
+                    onChange={(event) => setAmount(event.target.value)}
+                    className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                    placeholder="0.00"
+                    required
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label htmlFor="method" className="text-xs font-medium uppercase text-muted-foreground">
+                    Method
+                  </label>
+                  <select
+                    id="method"
+                    name="method"
+                    value={method}
+                    onChange={(event) => setMethod(event.target.value)}
+                    className="w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  >
+                    {paymentMethods.map((value) => (
+                      <option key={value} value={value}>
+                        {value.replace(/_/g, " ")}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <button
+                  type="submit"
+                  className="inline-flex w-full items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted"
+                  disabled={paymentMutation.isPending}
+                >
+                  {paymentMutation.isPending ? "Saving…" : "Apply payment"}
+                </button>
+              </form>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DataCard({ label, value, highlight = false }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div
+      className={`rounded-md border border-border/60 p-4 ${
+        highlight ? "bg-emerald-500/5 text-emerald-700 dark:text-emerald-300" : "bg-background"
+      }`}
+    >
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function LineItemRow({ item }: { item: InvoiceLineItem }) {
+  return (
+    <tr>
+      <td className="px-4 py-2 text-sm text-foreground">{item.description ?? "Line item"}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">{item.quantity}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">{formatCurrency(item.unitPrice)}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">{formatCurrency(item.cost)}</td>
+    </tr>
+  );
+}
+
+function PaymentRow({ payment }: { payment: InvoicePayment }) {
+  return (
+    <tr>
+      <td className="px-4 py-2 text-muted-foreground">{formatDate(payment.receivedAt)}</td>
+      <td className="px-4 py-2 text-muted-foreground">{payment.method}</td>
+      <td className="px-4 py-2 text-right text-foreground">{formatCurrency(payment.amount)}</td>
+      <td className="px-4 py-2 text-right text-muted-foreground">
+        {typeof payment.runningBalance === "number" ? formatCurrency(payment.runningBalance) : "—"}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/app/(staff)/invoices/page.tsx
+++ b/frontend/src/app/(staff)/invoices/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+
+import { useInvoices } from "@/hooks/use-invoices";
+import type { InvoiceSummary } from "@/services/invoices";
+
+function formatCurrency(value: number | null | undefined) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+const statusClasses: Record<string, string> = {
+  DRAFT: "bg-slate-200 text-slate-700",
+  SENT: "bg-blue-100 text-blue-700",
+  FINALIZED: "bg-violet-100 text-violet-700",
+  PARTIALLY_PAID: "bg-amber-100 text-amber-700",
+  PAID: "bg-emerald-100 text-emerald-700",
+  VOID: "bg-red-100 text-red-700",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const classes = statusClasses[status] ?? "bg-slate-200 text-slate-700";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${classes}`}>
+      {formatStatus(status)}
+    </span>
+  );
+}
+
+export default function InvoicesPage() {
+  const { data: invoices, isLoading, isError } = useInvoices();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-foreground">Invoices</h1>
+        <p className="text-sm text-muted-foreground">
+          Monitor billing statuses, outstanding balances, and follow-up needs in one place.
+        </p>
+      </header>
+
+      <div className="overflow-hidden rounded-md border border-border/70 bg-background shadow-sm">
+        <table className="min-w-full divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Invoice</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Customer</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Issued</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Due</th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Total</th>
+              <th className="px-4 py-3 text-right font-medium text-muted-foreground">Balance</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/70">
+            {isLoading && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                  Loading invoices…
+                </td>
+              </tr>
+            )}
+            {isError && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-destructive">
+                  Unable to load invoices. Please try again shortly.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && invoices && invoices.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                  No invoices yet. Finalize jobs to begin billing customers.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError &&
+              invoices?.map((invoice) => <InvoiceRow key={invoice.id} invoice={invoice} />)}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function InvoiceRow({ invoice }: { invoice: InvoiceSummary }) {
+  return (
+    <tr className="hover:bg-muted/30">
+      <td className="px-4 py-3">
+        <Link href={`/invoices/${invoice.id}`} className="font-semibold text-primary hover:underline">
+          #{invoice.number}
+        </Link>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{invoice.customer?.name ?? "—"}</td>
+      <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.issuedDate)}</td>
+      <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.dueDate)}</td>
+      <td className="px-4 py-3">
+        <StatusBadge status={invoice.status} />
+      </td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">{formatCurrency(invoice.total)}</td>
+      <td className="px-4 py-3 text-right font-medium text-foreground">
+        {formatCurrency(invoice.balanceDue)}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/dashboard/invoice-margin-insights.tsx
+++ b/frontend/src/components/dashboard/invoice-margin-insights.tsx
@@ -1,0 +1,95 @@
+import { Fragment } from "react";
+
+import type { InvoiceMarginAnalytics } from "@/services/invoices";
+
+import { StatCard } from "./stat-card";
+
+export type InvoiceMarginInsightsProps = {
+  analytics: InvoiceMarginAnalytics | null | undefined;
+  isLoading?: boolean;
+};
+
+export function InvoiceMarginInsights({ analytics, isLoading = false }: InvoiceMarginInsightsProps) {
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <div key={index} className="h-28 animate-pulse rounded-xl bg-muted/40" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!analytics) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-muted/10 p-6 text-sm text-muted-foreground">
+        Margin analytics will appear once invoices are finalized with cost data.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <StatCard
+          title="Average gross margin"
+          value={`${analytics.averageMarginPercent.toFixed(2)}%`}
+          hint={`Threshold ${analytics.threshold.toFixed(0)}%`}
+          tone={analytics.averageMarginPercent < analytics.threshold ? "warning" : "success"}
+        />
+        <StatCard
+          title="Invoices below threshold"
+          value={analytics.lowMarginInvoices}
+          hint="Review these jobs to protect profitability"
+          tone={analytics.lowMarginInvoices > 0 ? "critical" : "success"}
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border/60">
+        <table className="min-w-full divide-y divide-border/70 text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Invoice</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Customer</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Finalized</th>
+              <th className="px-4 py-2 text-right font-medium text-muted-foreground">Margin</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/70">
+            {analytics.series.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-4 text-center text-muted-foreground">
+                  No finalized invoices yet.
+                </td>
+              </tr>
+            ) : (
+              analytics.series.map((entry) => (
+                <Fragment key={entry.invoiceId}>
+                  <tr className={entry.isBelowThreshold ? "bg-red-500/5" : undefined}>
+                    <td className="px-4 py-2 font-medium text-foreground">#{entry.number}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{entry.customer ?? "—"}</td>
+                    <td className="px-4 py-2 text-muted-foreground">{formatDate(entry.finalizedAt)}</td>
+                    <td className="px-4 py-2 text-right font-semibold text-foreground">
+                      {entry.grossMarginPercent.toFixed(2)}%
+                    </td>
+                  </tr>
+                </Fragment>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return date.toLocaleDateString();
+}

--- a/frontend/src/components/layout/portal-shell.tsx
+++ b/frontend/src/components/layout/portal-shell.tsx
@@ -11,6 +11,7 @@ const navigation = [
   { label: "Dashboard", href: "/portal/dashboard" },
   { label: "Profile", href: "/portal/profile" },
   { label: "Warranty", href: "/portal/warranty" },
+  { label: "Invoices", href: "/portal/invoices" },
 ];
 
 type PortalShellProps = {

--- a/frontend/src/components/layout/staff-shell.tsx
+++ b/frontend/src/components/layout/staff-shell.tsx
@@ -14,16 +14,19 @@ const navigationByRole: Record<string, Array<{ label: string; href: string }>> =
   TECHNICIAN: [
     { label: "My Dashboard", href: "/dashboard" },
     { label: "Manager View", href: "/dashboard/manager" },
+    { label: "Invoices", href: "/invoices" },
   ],
   MANAGER: [
     { label: "Manager Dashboard", href: "/dashboard/manager" },
     { label: "Technician View", href: "/dashboard" },
     { label: "Admin Summary", href: "/dashboard/admin" },
+    { label: "Invoices", href: "/invoices" },
   ],
   ADMIN: [
     { label: "Admin Dashboard", href: "/dashboard/admin" },
     { label: "Manager Dashboard", href: "/dashboard/manager" },
     { label: "Technician Dashboard", href: "/dashboard" },
+    { label: "Invoices", href: "/invoices" },
   ],
 };
 
@@ -61,7 +64,11 @@ export function StaffShell({ children }: StaffShellProps) {
     });
   }, [pathname]);
 
-  const navigation = navigationByRole[role ?? ""] ?? [{ label: "Dashboard", href: "/dashboard" }];
+  const navigation =
+    navigationByRole[role ?? ""] ?? [
+      { label: "Dashboard", href: "/dashboard" },
+      { label: "Invoices", href: "/invoices" },
+    ];
   const { data: notifications } = useDashboardNotifications(role ?? null);
 
   if (!isAuthenticated && !isLoading) {

--- a/frontend/src/hooks/use-invoices.ts
+++ b/frontend/src/hooks/use-invoices.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  InvoiceDetail,
+  InvoiceMargin,
+  InvoiceMarginAnalytics,
+  InvoiceSummary,
+  ManualPaymentInput,
+  createStripeCheckout,
+  finalizeInvoice,
+  getInvoice,
+  getInvoiceMargin,
+  getInvoiceMarginAnalytics,
+  listInvoices,
+  recordManualPayment,
+} from "@/services/invoices";
+import { showToast } from "@/stores/toast-store";
+
+export function useInvoices() {
+  return useQuery<InvoiceSummary[]>({
+    queryKey: ["invoices"],
+    queryFn: listInvoices,
+  });
+}
+
+export function useInvoice(invoiceId: string) {
+  return useQuery<InvoiceDetail>({
+    queryKey: ["invoices", invoiceId],
+    queryFn: () => getInvoice(invoiceId),
+    enabled: Boolean(invoiceId),
+  });
+}
+
+export function useInvoiceMargin(invoiceId: string) {
+  return useQuery<InvoiceMargin>({
+    queryKey: ["invoices", invoiceId, "margin"],
+    queryFn: () => getInvoiceMargin(invoiceId),
+    enabled: Boolean(invoiceId),
+  });
+}
+
+export function useInvoiceMarginAnalytics() {
+  return useQuery<InvoiceMarginAnalytics>({
+    queryKey: ["invoices", "analytics", "margin"],
+    queryFn: getInvoiceMarginAnalytics,
+  });
+}
+
+export function useFinalizeInvoice(invoiceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => finalizeInvoice(invoiceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["invoices"] });
+      queryClient.invalidateQueries({ queryKey: ["invoices", invoiceId] });
+      showToast({
+        title: "Invoice finalized",
+        description: "The invoice is now locked for billing",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to finalize invoice",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useManualPayment(invoiceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: ManualPaymentInput) => recordManualPayment(invoiceId, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["invoices"] });
+      queryClient.invalidateQueries({ queryKey: ["invoices", invoiceId] });
+      showToast({
+        title: "Payment recorded",
+        description: "Balances updated with the new payment",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to record payment",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useStripeCheckout(invoiceId: string) {
+  return useMutation({
+    mutationFn: () => createStripeCheckout(invoiceId),
+    onSuccess: ({ checkout_url: checkoutUrl }) => {
+      if (checkoutUrl) {
+        window.location.href = checkoutUrl;
+      }
+    },
+    onError: (error: unknown) => {
+      showToast({
+        title: "Unable to start checkout",
+        description:
+          typeof error === "object" && error !== null && "message" in error
+            ? String((error as { message?: unknown }).message)
+            : "Unexpected error",
+        variant: "destructive",
+      });
+    },
+  });
+}

--- a/frontend/src/services/invoices.ts
+++ b/frontend/src/services/invoices.ts
@@ -1,0 +1,114 @@
+import { apiClient, get, post } from "@/lib/api/client";
+
+export type InvoiceStatus =
+  | "DRAFT"
+  | "SENT"
+  | "FINALIZED"
+  | "PARTIALLY_PAID"
+  | "PAID"
+  | "VOID";
+
+export interface InvoicePayment {
+  id: string;
+  amount: number;
+  method: string;
+  receivedAt: string;
+  runningBalance?: number;
+}
+
+export interface InvoiceLineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  cost: number;
+}
+
+export interface InvoiceSummary {
+  id: string;
+  number: string;
+  status: InvoiceStatus;
+  issuedDate: string | null;
+  dueDate: string | null;
+  total: number;
+  lateFee: number;
+  balanceDue: number;
+  customer: {
+    id: string | null;
+    name: string | null;
+    email?: string | null;
+  };
+  payments: InvoicePayment[];
+}
+
+export interface InvoiceDetail extends InvoiceSummary {
+  subtotal: number;
+  tax: number;
+  discountTotal: number;
+  loyalty: {
+    pointsEarned: number;
+    customerBalance: number;
+  };
+  items: InvoiceLineItem[];
+}
+
+export interface ManualPaymentInput {
+  amount: number;
+  method: string;
+}
+
+export interface InvoiceMargin {
+  invoiceId: string;
+  total_cost: number;
+  total_price: number;
+  gross_margin_percent: number;
+  threshold: number;
+  is_below_threshold: boolean;
+}
+
+export interface InvoiceMarginAnalytics {
+  averageMarginPercent: number;
+  lowMarginInvoices: number;
+  threshold: number;
+  series: Array<{
+    invoiceId: string;
+    number: string;
+    customer: string | null;
+    finalizedAt: string | null;
+    grossMarginPercent: number;
+    isBelowThreshold: boolean;
+  }>;
+}
+
+export async function listInvoices(): Promise<InvoiceSummary[]> {
+  return get<InvoiceSummary[]>("/invoice");
+}
+
+export async function getInvoice(invoiceId: string): Promise<InvoiceDetail> {
+  return get<InvoiceDetail>(`/invoice/${invoiceId}`);
+}
+
+export async function finalizeInvoice(invoiceId: string) {
+  return post(`/invoice/${invoiceId}/finalize`);
+}
+
+export async function recordManualPayment(invoiceId: string, payload: ManualPaymentInput) {
+  return post<InvoiceDetail>(`/invoice/${invoiceId}/pay`, payload);
+}
+
+export async function createStripeCheckout(invoiceId: string): Promise<{ checkout_url: string }> {
+  return post<{ checkout_url: string }>(`/invoice/${invoiceId}/pay/online`);
+}
+
+export async function downloadInvoicePdf(invoiceId: string): Promise<Blob> {
+  const response = await apiClient.get(`/invoice/${invoiceId}/pdf`, { responseType: "blob" });
+  return response.data as Blob;
+}
+
+export async function getInvoiceMargin(invoiceId: string): Promise<InvoiceMargin> {
+  return get<InvoiceMargin>(`/invoice/${invoiceId}/margin`);
+}
+
+export async function getInvoiceMarginAnalytics(): Promise<InvoiceMarginAnalytics> {
+  return get<InvoiceMarginAnalytics>("/invoice/analytics/margin");
+}


### PR DESCRIPTION
## Summary
- rewrite the invoice API surface to support listings, manual payments, Stripe checkout, margin analytics, and PDF downloads
- add invoice services/hooks plus staff and customer portal pages for invoice details, payments, and downloads
- surface margin insights on the manager dashboard and extend staff/portal navigation to include invoices

## Testing
- pytest *(fails: missing fastapi/pydantic/httpx dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e74a5c9510832ca09630a2780b53f9