### PR TITLE
feat: add staff inventory workflows

### DIFF
--- a/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
+++ b/frontend/src/app/(staff)/dashboard/_components/manager-dashboard.tsx
@@ -7,6 +7,7 @@ import { OverdueInvoicesTable } from "@/components/dashboard/overdue-invoices-ta
 import { SummaryFilters, type TechnicianOption } from "@/components/dashboard/summary-filters";
 import { SummaryGrid } from "@/components/dashboard/summary-grid";
 import { InvoiceMarginInsights } from "@/components/dashboard/invoice-margin-insights";
+import { RestockRecommendationsCard } from "@/components/inventory/restock-recommendations-card";
 import {
   useAdminSummary,
   useLowStockParts,
@@ -14,6 +15,7 @@ import {
   useSummaryCsv,
   useTechnicianOptions,
 } from "@/hooks/use-dashboard-data";
+import { useRestockRecommendations } from "@/hooks/use-inventory";
 import { useInvoiceMarginAnalytics } from "@/hooks/use-invoices";
 import type { AdminSummaryFilters } from "@/services/dashboard";
 
@@ -33,6 +35,7 @@ export function ManagerDashboardView() {
   const { data: technicians } = useTechnicianOptions();
   const { data: overdueInvoices } = useOverdueInvoices();
   const { data: lowStockParts } = useLowStockParts();
+  const { data: restockRecommendations, isLoading: isRestockLoading } = useRestockRecommendations();
   const { data: invoiceMargins, isLoading: isMarginsLoading } = useInvoiceMarginAnalytics();
   const csv = useSummaryCsv(metrics ?? [], filters);
 
@@ -83,6 +86,9 @@ export function ManagerDashboardView() {
       <div className="grid gap-6 lg:grid-cols-2">
         <OverdueInvoicesTable invoices={overdueInvoices ?? []} />
         <LowStockPartsTable parts={lowStockParts ?? []} />
+        <div className="lg:col-span-2">
+          <RestockRecommendationsCard items={restockRecommendations} isLoading={isRestockLoading} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/(staff)/inventory/layout.tsx
+++ b/frontend/src/app/(staff)/inventory/layout.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { clsx } from "clsx";
+
+const navigation = [
+  { label: "Part catalog", href: "/inventory" },
+  { label: "Stock transfers", href: "/inventory/transfers" },
+  { label: "Purchase orders", href: "/inventory/purchase-orders" },
+  { label: "Restock recommendations", href: "/inventory/restock" },
+];
+
+export default function InventoryLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border/60 bg-background/80 p-3">
+        <nav className="flex flex-wrap gap-2">
+          {navigation.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={clsx(
+                  "inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow"
+                    : "bg-muted/40 text-muted-foreground hover:bg-muted/60",
+                )}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/inventory/page.tsx
+++ b/frontend/src/app/(staff)/inventory/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+import { ConsumePartDialog } from "@/components/inventory/consume-part-dialog";
+import { PartCatalogTable } from "@/components/inventory/part-catalog-table";
+import { StockTransferDialog } from "@/components/inventory/stock-transfer-dialog";
+import { useConsumePart, useInventoryParts, useTransferStock } from "@/hooks/use-inventory";
+import type { InventoryPart, PartConsumptionPayload, StockTransferPayload } from "@/services/inventory";
+
+type ActiveDialog =
+  | { type: "transfer"; part: InventoryPart }
+  | { type: "consume"; part: InventoryPart }
+  | null;
+
+export default function InventoryCatalogPage() {
+  const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
+  const { data: parts, isLoading, error } = useInventoryParts();
+  const transferMutation = useTransferStock();
+  const consumeMutation = useConsumePart();
+
+  const handleTransfer = async (payload: StockTransferPayload) => {
+    await transferMutation.mutateAsync(payload);
+  };
+
+  const handleConsume = async (payload: PartConsumptionPayload & { note?: string | null }) => {
+    const { note: _note, ...rest } = payload;
+    await consumeMutation.mutateAsync(rest);
+  };
+
+  const closeDialog = () => setActiveDialog(null);
+
+  const errorMessage = error
+    ? typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "Unable to load parts")
+      : "Unable to load parts"
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Inventory catalog</h1>
+        <p className="text-sm text-muted-foreground">
+          Search the master part list, transfer stock between locations, and record consumption in real time.
+        </p>
+      </header>
+
+      <PartCatalogTable
+        parts={parts}
+        isLoading={isLoading}
+        error={errorMessage}
+        onTransfer={(part) => setActiveDialog({ type: "transfer", part })}
+        onConsume={(part) => setActiveDialog({ type: "consume", part })}
+      />
+
+      <StockTransferDialog
+        part={activeDialog?.type === "transfer" ? activeDialog.part : null}
+        open={activeDialog?.type === "transfer"}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+        onSubmit={handleTransfer}
+        isSubmitting={transferMutation.isPending}
+      />
+
+      <ConsumePartDialog
+        part={activeDialog?.type === "consume" ? activeDialog.part : null}
+        open={activeDialog?.type === "consume"}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+        onSubmit={handleConsume}
+        isSubmitting={consumeMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/inventory/purchase-orders/page.tsx
+++ b/frontend/src/app/(staff)/inventory/purchase-orders/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { PurchaseOrderSummary } from "@/components/inventory/purchase-order-summary";
+import { RestockRecommendationsCard } from "@/components/inventory/restock-recommendations-card";
+import {
+  useGeneratePurchaseOrders,
+  useGeneratedPurchaseOrders,
+  useInventorySummary,
+  useRestockByVendor,
+  useRestockRecommendations,
+} from "@/hooks/use-inventory";
+import { downloadPurchaseOrderPdf } from "@/services/inventory";
+import { showToast } from "@/stores/toast-store";
+
+export default function InventoryPurchaseOrdersPage() {
+  const [exportingId, setExportingId] = useState<string | null>(null);
+  const restockQuery = useRestockRecommendations();
+  const summaryQuery = useInventorySummary();
+  const purchaseOrdersQuery = useGeneratedPurchaseOrders();
+  const generateMutation = useGeneratePurchaseOrders();
+
+  const vendorGroups = useRestockByVendor(restockQuery.data);
+
+  const totalVendors = useMemo(() => vendorGroups.length, [vendorGroups]);
+
+  const handleGenerate = async () => {
+    await generateMutation.mutateAsync();
+  };
+
+  const handleExport = async (poId: string) => {
+    setExportingId(poId);
+    try {
+      const blob = await downloadPurchaseOrderPdf(poId);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `purchase-order-${poId}.pdf`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      showToast({
+        title: "Export ready",
+        description: "Purchase order PDF downloaded",
+        variant: "success",
+      });
+    } catch (error) {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to export PDF")
+          : "Unable to export PDF";
+      showToast({
+        title: "Export failed",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setExportingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Purchase order generation</h1>
+        <p className="text-sm text-muted-foreground">
+          Build vendor-ready purchase orders from low stock signals, then export PDFs or trigger downstream workflows.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-border/60 bg-background/80 p-4 shadow-sm">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Restock vendor summary</h2>
+            <p className="text-xs text-muted-foreground">
+              {restockQuery.isLoading
+                ? "Compiling vendor recommendations…"
+                : totalVendors === 0
+                  ? "All vendors are stocked above reorder thresholds."
+                  : `${totalVendors} vendors require replenishment.`}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleGenerate}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            disabled={generateMutation.isPending}
+          >
+            {generateMutation.isPending ? "Generating…" : "Generate purchase orders"}
+          </button>
+        </div>
+        {vendorGroups.length > 0 && (
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {vendorGroups.map((group) => (
+              <div key={group.vendor} className="rounded-lg border border-border/60 bg-muted/20 p-4">
+                <h3 className="text-sm font-semibold text-foreground">{group.vendor}</h3>
+                <p className="text-xs text-muted-foreground">{group.totalQuantity} total units suggested</p>
+                <ul className="mt-3 space-y-2 text-xs text-muted-foreground">
+                  {group.items.slice(0, 4).map((item) => (
+                    <li key={`${item.sku}-${item.quantity_to_order}`} className="flex justify-between gap-2">
+                      <span className="truncate">{item.name ?? item.sku}</span>
+                      <span className="font-medium text-foreground">×{item.quantity_to_order}</span>
+                    </li>
+                  ))}
+                </ul>
+                {group.items.length > 4 && (
+                  <p className="mt-2 text-[11px] text-muted-foreground">+{group.items.length - 4} more lines</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <RestockRecommendationsCard items={restockQuery.data} isLoading={restockQuery.isLoading} />
+        <PurchaseOrderSummary
+          purchaseOrders={purchaseOrdersQuery.data}
+          onExport={handleExport}
+          exportingId={exportingId}
+        />
+      </div>
+
+      {summaryQuery.data?.incoming_pos && summaryQuery.data.incoming_pos.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-foreground">Incoming deliveries</h2>
+          <p className="text-xs text-muted-foreground">
+            Monitor expected arrivals to coordinate receiving and technician scheduling.
+          </p>
+          <div className="overflow-hidden rounded-lg border border-border/60">
+            <table className="min-w-full divide-y divide-border/60 text-sm">
+              <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 text-left">SKU</th>
+                  <th className="px-4 py-2 text-left">Description</th>
+                  <th className="px-4 py-2 text-left">Expected arrival</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {summaryQuery.data.incoming_pos.map((item) => (
+                  <tr key={`${item.sku}-${item.expectedArrival ?? "unknown"}`} className="hover:bg-muted/30">
+                    <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{item.sku}</td>
+                    <td className="px-4 py-3 text-sm text-foreground">{item.description ?? "—"}</td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">{item.expectedArrival ?? "TBD"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/inventory/restock/page.tsx
+++ b/frontend/src/app/(staff)/inventory/restock/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { RestockRecommendationsCard } from "@/components/inventory/restock-recommendations-card";
+import { useInventorySummary, useRestockRecommendations } from "@/hooks/use-inventory";
+
+export default function InventoryRestockPage() {
+  const restockQuery = useRestockRecommendations();
+  const summaryQuery = useInventorySummary();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Restock recommendations</h1>
+        <p className="text-sm text-muted-foreground">
+          Review projected shortages, plan replenishment, and surface low-stock alerts for the team.
+        </p>
+      </header>
+
+      <RestockRecommendationsCard items={restockQuery.data} isLoading={restockQuery.isLoading} />
+
+      {summaryQuery.data && (
+        <section className="rounded-xl border border-border/60 bg-background/80 p-4">
+          <h2 className="text-lg font-semibold text-foreground">Inventory health overview</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <HealthStat label="Total tracked parts" value={summaryQuery.data.total_parts} />
+            <HealthStat label="Expired parts" value={summaryQuery.data.expired_parts} />
+            <HealthStat
+              label="Percent expired"
+              value={`${summaryQuery.data.expired_pct.toFixed(1)}%`}
+            />
+            <HealthStat
+              label="Stock value"
+              value={new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+              }).format(summaryQuery.data.stock_value)}
+            />
+          </div>
+          {summaryQuery.data.reorder_frequency.length > 0 && (
+            <div className="mt-6">
+              <h3 className="text-sm font-semibold text-foreground">Frequent reorders</h3>
+              <p className="text-xs text-muted-foreground">
+                Identify SKUs that repeatedly trigger replenishment to negotiate vendor programs.
+              </p>
+              <div className="mt-3 overflow-hidden rounded-lg border border-border/60">
+                <table className="min-w-full divide-y divide-border/60 text-sm">
+                  <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-2 text-left">SKU</th>
+                      <th className="px-4 py-2 text-right">Reorder count</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/60">
+                    {summaryQuery.data.reorder_frequency.slice(0, 10).map((item) => (
+                      <tr key={item.sku} className="hover:bg-muted/30">
+                        <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{item.sku}</td>
+                        <td className="px-4 py-3 text-right text-sm text-foreground">{item.reorderCount}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+type HealthStatProps = {
+  label: string;
+  value: number | string;
+};
+
+function HealthStat({ label, value }: HealthStatProps) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/inventory/transfers/page.tsx
+++ b/frontend/src/app/(staff)/inventory/transfers/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+import { PartCatalogTable } from "@/components/inventory/part-catalog-table";
+import { StockTransferDialog } from "@/components/inventory/stock-transfer-dialog";
+import { useInventoryParts, useTransferStock } from "@/hooks/use-inventory";
+import type { InventoryPart, StockTransferPayload } from "@/services/inventory";
+
+type TransferDialogState = { type: "transfer"; part: InventoryPart } | null;
+
+export default function InventoryTransfersPage() {
+  const [dialog, setDialog] = useState<TransferDialogState>(null);
+  const { data: parts, isLoading, error } = useInventoryParts();
+  const transferMutation = useTransferStock();
+
+  const errorMessage = error
+    ? typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message?: unknown }).message ?? "Unable to load parts")
+      : "Unable to load parts"
+    : null;
+
+  const handleTransfer = async (payload: StockTransferPayload) => {
+    await transferMutation.mutateAsync(payload);
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Stock transfers</h1>
+        <p className="text-sm text-muted-foreground">
+          Coordinate inventory moves between warehouses and mobile vans with validation against on-hand counts.
+        </p>
+      </header>
+
+      <PartCatalogTable
+        parts={parts}
+        isLoading={isLoading}
+        error={errorMessage}
+        onTransfer={(part) => setDialog({ type: "transfer", part })}
+      />
+
+      <StockTransferDialog
+        part={dialog?.part ?? null}
+        open={dialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setDialog(null);
+        }}
+        onSubmit={handleTransfer}
+        isSubmitting={transferMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/inventory/__stories__/inventory-dialogs.stories.tsx
+++ b/frontend/src/components/inventory/__stories__/inventory-dialogs.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { ConsumePartDialog } from "@/components/inventory/consume-part-dialog";
+import { StockTransferDialog } from "@/components/inventory/stock-transfer-dialog";
+
+const samplePart = {
+  id: "part-1",
+  sku: "ALT-001",
+  name: "Alternator",
+  description: "Remanufactured alternator",
+  quantity: 12,
+  reorderMin: 4,
+  location: "Main Warehouse",
+  vendor: "MotorWorks",
+};
+
+const meta: Meta<typeof StockTransferDialog> = {
+  title: "Inventory/Dialogs",
+  component: StockTransferDialog,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StockTransferDialog>;
+
+export const StockTransfer: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <StockTransferDialog
+        part={samplePart}
+        open={open}
+        onOpenChange={setOpen}
+        isSubmitting={false}
+        onSubmit={async () => {
+          console.log("submit transfer");
+        }}
+      />
+    );
+  },
+};
+
+export const ConsumePart: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <ConsumePartDialog
+        part={samplePart}
+        open={open}
+        onOpenChange={setOpen}
+        isSubmitting={false}
+        onSubmit={async () => {
+          console.log("record usage");
+        }}
+      />
+    );
+  },
+};

--- a/frontend/src/components/inventory/__stories__/part-catalog-table.stories.tsx
+++ b/frontend/src/components/inventory/__stories__/part-catalog-table.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PartCatalogTable } from "@/components/inventory/part-catalog-table";
+
+const meta: Meta<typeof PartCatalogTable> = {
+  title: "Inventory/PartCatalogTable",
+  component: PartCatalogTable,
+  args: {
+    parts: [
+      {
+        id: "part-1",
+        sku: "ALT-001",
+        name: "Alternator",
+        description: "Remanufactured alternator",
+        quantity: 8,
+        reorderMin: 5,
+        location: "Main Warehouse",
+        vendor: "MotorWorks",
+      },
+      {
+        id: "part-2",
+        sku: "BAT-220",
+        name: "Battery",
+        description: "AGM battery",
+        quantity: 2,
+        reorderMin: 4,
+        location: "Truck #3",
+        vendor: "VoltCo",
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PartCatalogTable>;
+
+export const Default: Story = {};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    parts: [],
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    onTransfer: () => console.log("transfer"),
+    onConsume: () => console.log("consume"),
+  },
+};

--- a/frontend/src/components/inventory/consume-part-dialog.tsx
+++ b/frontend/src/components/inventory/consume-part-dialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+import { validateConsumptionQuantity } from "@/hooks/use-inventory";
+import type { InventoryPart, PartConsumptionPayload } from "@/services/inventory";
+
+type ConsumePartFormValues = {
+  jobId: string;
+  quantity: number;
+  note?: string;
+};
+
+type ConsumePartDialogProps = {
+  part: InventoryPart | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (values: PartConsumptionPayload & { note?: string | null }) => Promise<void>;
+  isSubmitting?: boolean;
+};
+
+export function ConsumePartDialog({
+  part,
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting = false,
+}: ConsumePartDialogProps) {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const form = useForm<ConsumePartFormValues>({
+    defaultValues: {
+      jobId: "",
+      quantity: 1,
+      note: "",
+    },
+  });
+
+  const availableQuantity = part?.quantity ?? 0;
+
+  useEffect(() => {
+    if (!open) {
+      form.reset({ jobId: "", quantity: 1, note: "" });
+      setServerError(null);
+    }
+  }, [open, form]);
+
+  if (!open || !part) {
+    return null;
+  }
+
+  const quantityValue = form.watch("quantity");
+  const quantityError = validateConsumptionQuantity(quantityValue ?? 0, availableQuantity);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    const message = validateConsumptionQuantity(values.quantity ?? 0, availableQuantity);
+    if (message) {
+      form.setError("quantity", { message });
+      return;
+    }
+
+    if (!values.jobId) {
+      form.setError("jobId", { message: "Job reference is required" });
+      return;
+    }
+
+    setServerError(null);
+    try {
+      await onSubmit({
+        jobId: values.jobId,
+        partId: part.id,
+        quantity: values.quantity,
+        note: values.note || undefined,
+      });
+      onOpenChange(false);
+    } catch (error) {
+      const errorMessage =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to record usage")
+          : "Unable to record usage";
+      setServerError(errorMessage);
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-lg border border-border/60 bg-background p-6 shadow-xl">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-foreground">Consume part</h2>
+          <p className="text-xs text-muted-foreground">
+            Deduct <span className="font-medium text-foreground">{part.sku}</span> for a work order and update stock levels.
+          </p>
+        </div>
+        <form className="mt-4 space-y-4" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-2">
+            <label htmlFor="consume-job" className="text-sm font-medium text-foreground">
+              Job or work order ID
+            </label>
+            <input
+              id="consume-job"
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="e.g. RO-1024"
+              {...form.register("jobId", { required: "Job reference is required" })}
+            />
+            {form.formState.errors.jobId?.message && (
+              <p className="text-xs text-destructive">{form.formState.errors.jobId.message}</p>
+            )}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="consume-quantity" className="text-sm font-medium text-foreground">
+                Quantity
+              </label>
+              <input
+                id="consume-quantity"
+                type="number"
+                min={1}
+                max={availableQuantity}
+                className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                {...form.register("quantity", { valueAsNumber: true })}
+              />
+              {(form.formState.errors.quantity?.message || quantityError) && (
+                <p className="text-xs text-destructive">
+                  {form.formState.errors.quantity?.message ?? quantityError}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <span className="text-sm font-medium text-foreground">Available</span>
+              <p className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                {availableQuantity} units on hand
+              </p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="consume-note" className="text-sm font-medium text-foreground">
+              Notes (optional)
+            </label>
+            <textarea
+              id="consume-note"
+              className="h-20 w-full resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("note")}
+            />
+          </div>
+          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Recording…" : "Record usage"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/inventory/part-catalog-table.tsx
+++ b/frontend/src/components/inventory/part-catalog-table.tsx
@@ -1,0 +1,126 @@
+import type { InventoryPart } from "@/services/inventory";
+
+type PartCatalogTableProps = {
+  parts: InventoryPart[] | undefined;
+  isLoading?: boolean;
+  error?: string | null;
+  onTransfer?: (part: InventoryPart) => void;
+  onConsume?: (part: InventoryPart) => void;
+};
+
+export function PartCatalogTable({
+  parts,
+  isLoading = false,
+  error,
+  onTransfer,
+  onConsume,
+}: PartCatalogTableProps) {
+  const hasActions = Boolean(onTransfer || onConsume);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70 bg-background shadow-sm">
+      <table className="min-w-full divide-y divide-border/70 text-sm">
+        <thead className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th scope="col" className="px-4 py-2 text-left">
+              SKU
+            </th>
+            <th scope="col" className="px-4 py-2 text-left">
+              Description
+            </th>
+            <th scope="col" className="px-4 py-2 text-left">
+              Location
+            </th>
+            <th scope="col" className="px-4 py-2 text-right">
+              On hand
+            </th>
+            <th scope="col" className="px-4 py-2 text-right">
+              Min
+            </th>
+            <th scope="col" className="px-4 py-2 text-left">
+              Vendor
+            </th>
+            {hasActions && (
+              <th scope="col" className="px-4 py-2 text-right">
+                Actions
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/70">
+          {isLoading && (
+            <tr>
+              <td colSpan={hasActions ? 7 : 6} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                Loading parts…
+              </td>
+            </tr>
+          )}
+          {error && !isLoading && (
+            <tr>
+              <td colSpan={hasActions ? 7 : 6} className="px-4 py-6 text-center text-sm text-destructive">
+                {error}
+              </td>
+            </tr>
+          )}
+          {!isLoading && !error && (parts?.length ?? 0) === 0 && (
+            <tr>
+              <td colSpan={hasActions ? 7 : 6} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                No parts found. Adjust filters or sync your catalog.
+              </td>
+            </tr>
+          )}
+          {!isLoading && !error &&
+            parts?.map((part) => {
+              const belowMin =
+                typeof part.reorderMin === "number" && part.reorderMin !== null && part.quantity < part.reorderMin;
+              return (
+                <tr key={`${part.id}-${part.location ?? "default"}`} className="hover:bg-muted/30">
+                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{part.sku}</td>
+                  <td className="px-4 py-3 text-sm text-foreground">
+                    {part.description || part.name || "Unlabeled part"}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{part.location ?? "Default"}</td>
+                  <td className="px-4 py-3 text-right text-sm font-semibold text-foreground">
+                    {part.quantity}
+                  </td>
+                  <td className="px-4 py-3 text-right text-xs text-muted-foreground">
+                    {typeof part.reorderMin === "number" && part.reorderMin !== null ? part.reorderMin : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{part.vendor ?? "—"}</td>
+                  {hasActions && (
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-2">
+                        {onTransfer && (
+                          <button
+                            type="button"
+                            onClick={() => onTransfer(part)}
+                            className="inline-flex items-center rounded-md border border-border/70 px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                          >
+                            Transfer
+                          </button>
+                        )}
+                        {onConsume && (
+                          <button
+                            type="button"
+                            onClick={() => onConsume(part)}
+                            className="inline-flex items-center rounded-md border border-border/70 px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                          >
+                            Consume
+                          </button>
+                        )}
+                      </div>
+                      {belowMin && (
+                        <p className="mt-2 text-right text-[11px] text-amber-600">
+                          Below minimum threshold
+                        </p>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/inventory/purchase-order-summary.tsx
+++ b/frontend/src/components/inventory/purchase-order-summary.tsx
@@ -1,0 +1,75 @@
+import { formatDistanceToNow } from "date-fns";
+
+import type { PurchaseOrderRecord } from "@/services/inventory";
+
+type PurchaseOrderSummaryProps = {
+  purchaseOrders: PurchaseOrderRecord[] | undefined;
+  onExport: (purchaseOrderId: string) => void;
+  exportingId?: string | null;
+};
+
+function formatStatus(status?: string | null) {
+  if (!status) return "DRAFT";
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function PurchaseOrderSummary({
+  purchaseOrders,
+  onExport,
+  exportingId,
+}: PurchaseOrderSummaryProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/80">
+      <div className="border-b border-border/60 px-4 py-3">
+        <h3 className="text-sm font-semibold text-foreground">Generated purchase orders</h3>
+        <p className="text-xs text-muted-foreground">
+          Track approval status, export PDFs, and monitor vendor notifications.
+        </p>
+      </div>
+      <div className="divide-y divide-border/60">
+        {(purchaseOrders?.length ?? 0) === 0 ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            Generate purchase orders to see vendor summaries here.
+          </div>
+        ) : (
+          purchaseOrders?.map((po) => {
+            const createdAt = po.createdAt ? new Date(po.createdAt) : null;
+            const relative = createdAt ? formatDistanceToNow(createdAt, { addSuffix: true }) : "Recently";
+            return (
+              <div key={po.id} className="px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">PO #{po.id.slice(0, 8)}</p>
+                    <p className="text-xs text-muted-foreground">Vendor: {po.vendor ?? "Unassigned"}</p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                      {formatStatus(po.status)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">{relative}</span>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <p>{po.items?.length ?? 0} line items</p>
+                  {po.emailSent && <p className="text-emerald-600">Vendor email sent</p>}
+                  <button
+                    type="button"
+                    onClick={() => onExport(po.id)}
+                    className="inline-flex items-center rounded-md border border-border px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                    disabled={exportingId === po.id}
+                  >
+                    {exportingId === po.id ? "Preparing…" : "Export PDF"}
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/inventory/restock-recommendations-card.tsx
+++ b/frontend/src/components/inventory/restock-recommendations-card.tsx
@@ -1,0 +1,41 @@
+import type { RestockSuggestion } from "@/services/inventory";
+
+type RestockRecommendationsCardProps = {
+  items: RestockSuggestion[] | undefined;
+  isLoading?: boolean;
+};
+
+export function RestockRecommendationsCard({ items, isLoading = false }: RestockRecommendationsCardProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/80">
+      <div className="border-b border-border/60 px-4 py-3">
+        <h3 className="text-sm font-semibold text-foreground">Restock recommendations</h3>
+        <p className="text-xs text-muted-foreground">
+          Suggested replenishment quantities grouped by vendor priority.
+        </p>
+      </div>
+      <div className="divide-y divide-border/60">
+        {isLoading && (
+          <div className="px-4 py-6 text-sm text-muted-foreground">Calculating reorder suggestions…</div>
+        )}
+        {!isLoading && (items?.length ?? 0) === 0 && (
+          <div className="px-4 py-6 text-sm text-muted-foreground">All parts are within healthy stock ranges.</div>
+        )}
+        {!isLoading &&
+          items?.map((item) => (
+            <div key={`${item.sku}-${item.vendor ?? "unknown"}`} className="px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{item.name ?? item.sku}</p>
+                  <p className="text-xs text-muted-foreground">Vendor: {item.vendor ?? "Unassigned"}</p>
+                </div>
+                <span className="inline-flex h-8 min-w-[3.5rem] items-center justify-center rounded-md bg-primary/10 px-3 text-sm font-semibold text-primary">
+                  {item.quantity_to_order}
+                </span>
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/inventory/stock-transfer-dialog.tsx
+++ b/frontend/src/components/inventory/stock-transfer-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+import type { InventoryPart, StockTransferPayload } from "@/services/inventory";
+import { validateTransferQuantity } from "@/hooks/use-inventory";
+
+type StockTransferFormValues = {
+  toLocation: string;
+  quantity: number;
+  note?: string;
+};
+
+type StockTransferDialogProps = {
+  part: InventoryPart | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (values: StockTransferPayload) => Promise<void>;
+  isSubmitting?: boolean;
+};
+
+export function StockTransferDialog({
+  part,
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting = false,
+}: StockTransferDialogProps) {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const form = useForm<StockTransferFormValues>({
+    defaultValues: {
+      toLocation: "",
+      quantity: 1,
+      note: "",
+    },
+  });
+
+  const availableQuantity = part?.quantity ?? 0;
+
+  useEffect(() => {
+    if (!open) {
+      form.reset({ toLocation: "", quantity: 1, note: "" });
+      setServerError(null);
+    }
+  }, [open, form]);
+
+  const quantityValue = form.watch("quantity");
+  const validationMessage = validateTransferQuantity(quantityValue ?? 0, availableQuantity);
+
+  if (!open || !part) {
+    return null;
+  }
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    const errorMessage = validateTransferQuantity(values.quantity ?? 0, availableQuantity);
+    if (errorMessage) {
+      form.setError("quantity", { message: errorMessage });
+      return;
+    }
+
+    setServerError(null);
+    try {
+      await onSubmit({
+        partId: part.id,
+        fromLocation: part.location ?? "", 
+        toLocation: values.toLocation,
+        quantity: values.quantity,
+        note: values.note || undefined,
+      });
+      onOpenChange(false);
+    } catch (error) {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to transfer stock")
+          : "Unable to transfer stock";
+      setServerError(message);
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-lg border border-border/60 bg-background p-6 shadow-xl">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-foreground">Transfer stock</h2>
+          <p className="text-xs text-muted-foreground">
+            Move <span className="font-medium text-foreground">{part.sku}</span> from {part.location ?? "default location"} to a new site.
+          </p>
+        </div>
+        <form className="mt-4 space-y-4" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-2">
+            <label htmlFor="transfer-to" className="text-sm font-medium text-foreground">
+              Destination location
+            </label>
+            <input
+              id="transfer-to"
+              type="text"
+              className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="e.g. Truck #2"
+              {...form.register("toLocation", { required: "Destination is required" })}
+            />
+            {form.formState.errors.toLocation?.message && (
+              <p className="text-xs text-destructive">{form.formState.errors.toLocation.message}</p>
+            )}
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="transfer-quantity" className="text-sm font-medium text-foreground">
+                Quantity
+              </label>
+              <input
+                id="transfer-quantity"
+                type="number"
+                min={1}
+                max={availableQuantity}
+                className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                {...form.register("quantity", { valueAsNumber: true })}
+              />
+              {(form.formState.errors.quantity?.message || validationMessage) && (
+                <p className="text-xs text-destructive">
+                  {form.formState.errors.quantity?.message ?? validationMessage}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <span className="text-sm font-medium text-foreground">Available</span>
+              <p className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                {availableQuantity} units on hand
+              </p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="transfer-note" className="text-sm font-medium text-foreground">
+              Notes (optional)
+            </label>
+            <textarea
+              id="transfer-note"
+              className="h-20 w-full resize-none rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              {...form.register("note")}
+            />
+          </div>
+          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Transferring…" : "Transfer"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/staff-shell.tsx
+++ b/frontend/src/components/layout/staff-shell.tsx
@@ -15,18 +15,21 @@ const navigationByRole: Record<string, Array<{ label: string; href: string }>> =
     { label: "My Dashboard", href: "/dashboard" },
     { label: "Manager View", href: "/dashboard/manager" },
     { label: "Invoices", href: "/invoices" },
+    { label: "Inventory", href: "/inventory" },
   ],
   MANAGER: [
     { label: "Manager Dashboard", href: "/dashboard/manager" },
     { label: "Technician View", href: "/dashboard" },
     { label: "Admin Summary", href: "/dashboard/admin" },
     { label: "Invoices", href: "/invoices" },
+    { label: "Inventory", href: "/inventory" },
   ],
   ADMIN: [
     { label: "Admin Dashboard", href: "/dashboard/admin" },
     { label: "Manager Dashboard", href: "/dashboard/manager" },
     { label: "Technician Dashboard", href: "/dashboard" },
     { label: "Invoices", href: "/invoices" },
+    { label: "Inventory", href: "/inventory" },
   ],
 };
 

--- a/frontend/src/hooks/__tests__/use-inventory.test.tsx
+++ b/frontend/src/hooks/__tests__/use-inventory.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import {
+  inventoryKeys,
+  useConsumePart,
+  useTransferStock,
+  validateConsumptionQuantity,
+  validateTransferQuantity,
+} from "@/hooks/use-inventory";
+import type { InventoryPart } from "@/services/inventory";
+import * as inventoryService from "@/services/inventory";
+
+vi.mock("@/stores/toast-store", () => ({
+  showToast: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("quantity validation", () => {
+  it("rejects zero or negative transfers", () => {
+    expect(validateTransferQuantity(0, 10)).toBe("Quantity must be at least 1");
+    expect(validateTransferQuantity(-3, 10)).toBe("Quantity must be at least 1");
+  });
+
+  it("rejects transfers above available inventory", () => {
+    expect(validateTransferQuantity(12, 8)).toBe("Cannot transfer more than 8 units");
+  });
+
+  it("rejects consumption above available inventory", () => {
+    expect(validateConsumptionQuantity(5, 2)).toBe("Only 2 units available");
+  });
+
+  it("accepts valid quantities", () => {
+    expect(validateTransferQuantity(4, 10)).toBeNull();
+    expect(validateConsumptionQuantity(2, 5)).toBeNull();
+  });
+});
+
+describe("inventory cache updates", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reduces quantity after transfer", async () => {
+    const queryClient = new QueryClient();
+    const initialParts: InventoryPart[] = [
+      { id: "part-1", sku: "ABC", quantity: 12, reorderMin: 4, reorderMax: null, location: "Main", vendor: "Vendor" },
+    ];
+    queryClient.setQueryData(inventoryKeys.parts(), initialParts);
+    const transferSpy = vi
+      .spyOn(inventoryService, "transferStock")
+      .mockResolvedValue({ message: "Transfer complete" } as never);
+
+    const { result } = renderHook(() => useTransferStock(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        partId: "part-1",
+        fromLocation: "Main",
+        toLocation: "Truck",
+        quantity: 5,
+      });
+    });
+
+    const updated = queryClient.getQueryData<InventoryPart[]>(inventoryKeys.parts());
+    expect(updated?.[0].quantity).toBe(7);
+    expect(transferSpy).toHaveBeenCalledWith({
+      partId: "part-1",
+      fromLocation: "Main",
+      toLocation: "Truck",
+      quantity: 5,
+    });
+  });
+
+  it("reduces quantity after consumption", async () => {
+    const queryClient = new QueryClient();
+    const initialParts: InventoryPart[] = [
+      { id: "part-2", sku: "XYZ", quantity: 6, reorderMin: 2, reorderMax: null, location: "Main", vendor: "Vendor" },
+    ];
+    queryClient.setQueryData(inventoryKeys.parts(), initialParts);
+
+    const consumeSpy = vi
+      .spyOn(inventoryService, "consumePart")
+      .mockResolvedValue({ id: "usage-1", jobId: "job-1", partId: "part-2", quantity: 3 } as never);
+
+    const { result } = renderHook(() => useConsumePart(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ jobId: "job-1", partId: "part-2", quantity: 3 });
+    });
+
+    const updated = queryClient.getQueryData<InventoryPart[]>(inventoryKeys.parts());
+    expect(updated?.[0].quantity).toBe(3);
+    expect(consumeSpy).toHaveBeenCalledWith({ jobId: "job-1", partId: "part-2", quantity: 3 });
+  });
+});

--- a/frontend/src/hooks/use-inventory.ts
+++ b/frontend/src/hooks/use-inventory.ts
@@ -1,0 +1,245 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import {
+  consumePart as consumePartRequest,
+  fetchInventoryParts,
+  fetchInventorySummary,
+  fetchRestockSuggestions,
+  generatePurchaseOrders,
+  transferStock as transferStockRequest,
+  type FetchInventoryPartsParams,
+  type InventoryPart,
+  type InventorySummary,
+  type PartConsumptionPayload,
+  type PurchaseOrderGenerationResponse,
+  type PurchaseOrderRecord,
+  type RestockSuggestion,
+  type StockTransferPayload,
+} from "@/services/inventory";
+import { showToast } from "@/stores/toast-store";
+
+export const inventoryKeys = {
+  parts: (filters: FetchInventoryPartsParams = {}) =>
+    ["inventory", "parts", filters] as const,
+  restock: () => ["inventory", "restock", "recommendations"] as const,
+  summary: () => ["inventory", "summary"] as const,
+  purchaseOrders: () => ["inventory", "purchase-orders"] as const,
+};
+
+function clampQuantity(quantity: number) {
+  if (!Number.isFinite(quantity)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(quantity));
+}
+
+export function validateTransferQuantity(
+  quantity: number,
+  available: number,
+): string | null {
+  const normalized = clampQuantity(quantity);
+  if (normalized <= 0) {
+    return "Quantity must be at least 1";
+  }
+  if (normalized > available) {
+    return `Cannot transfer more than ${available} units`;
+  }
+  return null;
+}
+
+export function validateConsumptionQuantity(
+  quantity: number,
+  available: number,
+): string | null {
+  const normalized = clampQuantity(quantity);
+  if (normalized <= 0) {
+    return "Quantity must be at least 1";
+  }
+  if (normalized > available) {
+    return `Only ${available} units available`; 
+  }
+  return null;
+}
+
+function updatePartQuantityCache(
+  queryClient: QueryClient,
+  updater: (part: InventoryPart) => InventoryPart,
+) {
+  const queries = queryClient.getQueryCache().findAll({
+    queryKey: ["inventory", "parts"],
+  });
+
+  for (const query of queries) {
+    const key = query.queryKey as ReturnType<typeof inventoryKeys.parts>;
+    queryClient.setQueryData<InventoryPart[] | undefined>(key, (previous) => {
+      if (!previous) {
+        return previous;
+      }
+      return previous.map((part) => updater(part));
+    });
+  }
+}
+
+export function useInventoryParts(filters: FetchInventoryPartsParams = {}) {
+  return useQuery<InventoryPart[]>({
+    queryKey: inventoryKeys.parts(filters),
+    queryFn: () => fetchInventoryParts(filters),
+    staleTime: 60_000,
+  });
+}
+
+export function useRestockRecommendations() {
+  return useQuery<RestockSuggestion[]>({
+    queryKey: inventoryKeys.restock(),
+    queryFn: async () => {
+      const response = await fetchRestockSuggestions();
+      return response.items ?? [];
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useInventorySummary() {
+  return useQuery<InventorySummary>({
+    queryKey: inventoryKeys.summary(),
+    queryFn: fetchInventorySummary,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useGeneratedPurchaseOrders() {
+  return useQuery<PurchaseOrderRecord[]>({
+    queryKey: inventoryKeys.purchaseOrders(),
+    queryFn: async () => [],
+    initialData: [],
+    staleTime: Infinity,
+  });
+}
+
+export function useTransferStock() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: transferStockRequest,
+    onSuccess: (response, variables) => {
+      updatePartQuantityCache(queryClient, (part) => {
+        if (part.id !== variables.partId) {
+          return part;
+        }
+        return {
+          ...part,
+          quantity: Math.max(part.quantity - variables.quantity, 0),
+        };
+      });
+      queryClient.invalidateQueries({ queryKey: inventoryKeys.summary() });
+      showToast({
+        title: "Transfer complete",
+        description: response.message ?? "Stock transfer recorded",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to transfer stock")
+          : "Unable to transfer stock";
+      showToast({
+        title: "Transfer failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useConsumePart() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: consumePartRequest,
+    onSuccess: (_response, variables) => {
+      updatePartQuantityCache(queryClient, (part) => {
+        if (part.id !== variables.partId) {
+          return part;
+        }
+        return {
+          ...part,
+          quantity: Math.max(part.quantity - variables.quantity, 0),
+        };
+      });
+      queryClient.invalidateQueries({ queryKey: inventoryKeys.summary() });
+      showToast({
+        title: "Part consumed",
+        description: "Usage recorded against the job",
+        variant: "success",
+      });
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to record usage")
+          : "Unable to record usage";
+      showToast({
+        title: "Usage failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useGeneratePurchaseOrders() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: generatePurchaseOrders,
+    onSuccess: (response: PurchaseOrderGenerationResponse) => {
+      const created = response.created ?? [];
+      queryClient.setQueryData<PurchaseOrderRecord[]>(
+        inventoryKeys.purchaseOrders(),
+        created,
+      );
+      queryClient.invalidateQueries({ queryKey: inventoryKeys.summary() });
+      showToast({
+        title: "Purchase orders generated",
+        description: created.length
+          ? `${created.length} vendor orders queued and email notifications sent`
+          : "No purchase orders were required",
+        variant: created.length ? "success" : "warning",
+      });
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to generate purchase orders")
+          : "Unable to generate purchase orders";
+      showToast({
+        title: "Generation failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+}
+
+export function useRestockByVendor(recommendations: RestockSuggestion[] | undefined) {
+  return useMemo(() => {
+    const groups = new Map<string, RestockSuggestion[]>();
+    for (const item of recommendations ?? []) {
+      const vendor = item.vendor ?? "Unassigned";
+      const current = groups.get(vendor) ?? [];
+      current.push(item);
+      groups.set(vendor, current);
+    }
+    return Array.from(groups.entries()).map(([vendor, items]) => ({
+      vendor,
+      items,
+      totalQuantity: items.reduce((total, entry) => total + (entry.quantity_to_order ?? 0), 0),
+    }));
+  }, [recommendations]);
+}

--- a/frontend/src/services/inventory.ts
+++ b/frontend/src/services/inventory.ts
@@ -1,0 +1,115 @@
+import { get, post } from "@/lib/api/client";
+
+export interface InventoryPart {
+  id: string;
+  sku: string;
+  name?: string | null;
+  description?: string | null;
+  quantity: number;
+  reorderMin?: number | null;
+  reorderMax?: number | null;
+  location?: string | null;
+  vendor?: string | null;
+  cost?: number | null;
+}
+
+export interface FetchInventoryPartsParams {
+  location?: string;
+}
+
+export interface StockTransferPayload {
+  partId: string;
+  fromLocation: string;
+  toLocation: string;
+  quantity: number;
+  note?: string | null;
+}
+
+export interface StockTransferResponse {
+  message: string;
+}
+
+export interface PartConsumptionPayload {
+  jobId: string;
+  partId: string;
+  quantity: number;
+}
+
+export interface PartConsumptionResponse {
+  id: string;
+  jobId: string;
+  partId: string;
+  quantity: number;
+}
+
+export interface RestockSuggestion {
+  sku: string;
+  name?: string | null;
+  vendor?: string | null;
+  quantity_to_order: number;
+}
+
+export interface RestockSuggestionsResponse {
+  items: RestockSuggestion[];
+}
+
+export interface PurchaseOrderRecord {
+  id: string;
+  vendor?: string | null;
+  status?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  emailSent?: boolean;
+  items?: Array<{ partId: string; quantity: number; cost?: number | null }>;
+}
+
+export interface PurchaseOrderGenerationResponse {
+  created: PurchaseOrderRecord[];
+}
+
+export interface InventorySummary {
+  total_parts: number;
+  expired_parts: number;
+  expired_pct: number;
+  stock_value: number;
+  reorder_frequency: Array<{ sku: string; reorderCount: number }>;
+  incoming_pos: Array<{
+    sku: string;
+    description?: string | null;
+    expectedArrival?: string | null;
+  }>;
+}
+
+export async function fetchInventoryParts(params: FetchInventoryPartsParams = {}) {
+  return get<InventoryPart[]>("/inventory/parts", {
+    params: {
+      location: params.location || undefined,
+    },
+  });
+}
+
+export async function transferStock(payload: StockTransferPayload) {
+  return post<StockTransferResponse>("/inventory/stock/transfer", payload);
+}
+
+export async function consumePart(payload: PartConsumptionPayload) {
+  return post<PartConsumptionResponse>("/inventory/consume", payload);
+}
+
+export async function fetchRestockSuggestions() {
+  return post<RestockSuggestionsResponse>("/inventory/restock-orders/generate");
+}
+
+export async function generatePurchaseOrders() {
+  return post<PurchaseOrderGenerationResponse>("/inventory/purchase-orders/create");
+}
+
+export async function fetchInventorySummary() {
+  return get<InventorySummary>("/inventory/summary");
+}
+
+export async function downloadPurchaseOrderPdf(poId: string) {
+  return get<Blob>(`/inventory/purchase-orders/${poId}/pdf`, {
+    responseType: "blob",
+  });
+}


### PR DESCRIPTION
## Summary
- add inventory services, hooks, and UI to deliver catalog, transfer, purchase-order, and restock staff pages
- surface inventory alerts in dashboards and navigation, including new restock recommendation card
- cover quantity validation, React Query caching, and provide Storybook stories for inventory tables and dialogs

## Testing
- npm run test:unit *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74e93e8d4832c94a5df9919bdf1e3