### PR TITLE
Connect inventory purchase orders to API

### DIFF
--- a/frontend/src/hooks/__tests__/use-inventory.test.tsx
+++ b/frontend/src/hooks/__tests__/use-inventory.test.tsx
@@ -1,20 +1,39 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import {
   inventoryKeys,
   useConsumePart,
+  useGeneratePurchaseOrders,
+  useGeneratedPurchaseOrders,
   useTransferStock,
   validateConsumptionQuantity,
   validateTransferQuantity,
 } from "@/hooks/use-inventory";
-import type { InventoryPart } from "@/services/inventory";
+import type { InventoryPart, PurchaseOrderRecord } from "@/services/inventory";
 import * as inventoryService from "@/services/inventory";
 
 vi.mock("@/stores/toast-store", () => ({
   showToast: vi.fn(),
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
 
 function createWrapper(queryClient: QueryClient) {
   return ({ children }: { children: ReactNode }) => (
@@ -43,12 +62,8 @@ describe("quantity validation", () => {
 });
 
 describe("inventory cache updates", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("reduces quantity after transfer", async () => {
-    const queryClient = new QueryClient();
+    const queryClient = createTestQueryClient();
     const initialParts: InventoryPart[] = [
       { id: "part-1", sku: "ABC", quantity: 12, reorderMin: 4, reorderMax: null, location: "Main", vendor: "Vendor" },
     ];
@@ -81,7 +96,7 @@ describe("inventory cache updates", () => {
   });
 
   it("reduces quantity after consumption", async () => {
-    const queryClient = new QueryClient();
+    const queryClient = createTestQueryClient();
     const initialParts: InventoryPart[] = [
       { id: "part-2", sku: "XYZ", quantity: 6, reorderMin: 2, reorderMax: null, location: "Main", vendor: "Vendor" },
     ];
@@ -102,5 +117,59 @@ describe("inventory cache updates", () => {
     const updated = queryClient.getQueryData<InventoryPart[]>(inventoryKeys.parts());
     expect(updated?.[0].quantity).toBe(3);
     expect(consumeSpy).toHaveBeenCalledWith({ jobId: "job-1", partId: "part-2", quantity: 3 });
+  });
+});
+
+describe("purchase order workflows", () => {
+  it("fetches generated purchase orders from the API", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const existing: PurchaseOrderRecord[] = [
+      { id: "po-1", vendor: "Vendor A", status: "SENT", createdAt: new Date().toISOString(), updatedAt: null, emailSent: true },
+    ];
+
+    const fetchSpy = vi
+      .spyOn(inventoryService, "fetchPurchaseOrders")
+      .mockResolvedValue(existing as never);
+
+    const { result } = renderHook(() => useGeneratedPurchaseOrders(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(existing);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores newly generated purchase orders and merges with cache", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createWrapper(queryClient);
+    const previous: PurchaseOrderRecord[] = [
+      { id: "po-existing", vendor: "Vendor C", status: "DRAFT", createdAt: null, updatedAt: null, emailSent: false },
+    ];
+    queryClient.setQueryData(inventoryKeys.purchaseOrders(), previous);
+
+    const created: PurchaseOrderRecord[] = [
+      { id: "po-1", vendor: "Vendor A", status: "SENT", createdAt: new Date().toISOString(), updatedAt: null, emailSent: true },
+      { id: "po-existing", vendor: "Vendor C", status: "SENT", createdAt: null, updatedAt: null, emailSent: true },
+    ];
+
+    vi.spyOn(inventoryService, "fetchPurchaseOrders").mockResolvedValue(created as never);
+
+    const generateSpy = vi
+      .spyOn(inventoryService, "generatePurchaseOrders")
+      .mockResolvedValue({ created } as never);
+
+    const { result } = renderHook(() => useGeneratePurchaseOrders(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    await waitFor(() => {
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+      const cached = queryClient.getQueryData<PurchaseOrderRecord[]>(inventoryKeys.purchaseOrders());
+      expect(cached).toEqual(created);
+    });
   });
 });

--- a/frontend/src/services/inventory.ts
+++ b/frontend/src/services/inventory.ts
@@ -104,6 +104,10 @@ export async function generatePurchaseOrders() {
   return post<PurchaseOrderGenerationResponse>("/inventory/purchase-orders/create");
 }
 
+export async function fetchPurchaseOrders() {
+  return get<PurchaseOrderRecord[]>("/inventory/purchase-orders");
+}
+
 export async function fetchInventorySummary() {
   return get<InventorySummary>("/inventory/summary");
 }


### PR DESCRIPTION
## Summary
- add a dedicated API client for fetching generated purchase orders and wire the React Query hook to use it
- extend the purchase order generation mutation to merge new records, refresh caches, and keep dashboard data in sync
- expand unit coverage for inventory hooks to include purchase order fetching and cache updates

## Testing
- npm run test -- --runInBand *(fails: vitest binary unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e84a518a24832cb9d3db06fe376dfd