### PR TITLE
Add warranty triage workflows

### DIFF
--- a/frontend/src/app/(portal)/portal/warranty/page.tsx
+++ b/frontend/src/app/(portal)/portal/warranty/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 
 import { getWarrantyHistory } from "@/services/customers";
@@ -27,6 +28,12 @@ export default function WarrantyHistoryPage() {
         <p className="text-sm text-muted-foreground">
           Review your submitted warranty claims and track their progress with our service team.
         </p>
+        <Link
+          href="/portal/warranty/submit"
+          className="inline-flex items-center rounded-md border border-primary/30 bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary transition hover:bg-primary/20"
+        >
+          Submit a new claim
+        </Link>
       </header>
 
       {claims.length ? (

--- a/frontend/src/app/(portal)/portal/warranty/submit/page.tsx
+++ b/frontend/src/app/(portal)/portal/warranty/submit/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { submitWarrantyClaim } from "@/services/warranty";
+import { showToast } from "@/stores/toast-store";
+
+export default function WarrantySubmitPage() {
+  const router = useRouter();
+  const [workOrderId, setWorkOrderId] = useState("");
+  const [description, setDescription] = useState("");
+  const [attachment, setAttachment] = useState<File | null>(null);
+
+  const submitMutation = useMutation({
+    mutationFn: submitWarrantyClaim,
+    onSuccess: () => {
+      showToast({
+        title: "Warranty claim submitted",
+        description: "Our team will review your submission and follow up shortly.",
+        variant: "success",
+      });
+      router.push("/portal/warranty");
+    },
+    onError: (error) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to submit claim")
+          : "Unable to submit claim";
+      showToast({
+        title: "Submission failed",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!workOrderId.trim() || !description.trim()) {
+      showToast({
+        title: "Missing information",
+        description: "Work order ID and issue description are required.",
+        variant: "warning",
+      });
+      return;
+    }
+
+    submitMutation.mutate({
+      workOrderId: workOrderId.trim(),
+      description: description.trim(),
+      attachment,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Submit warranty claim</h1>
+        <p className="text-sm text-muted-foreground">
+          Provide details about the issue you are experiencing. Our warranty specialists will respond within 48 hours.
+        </p>
+        <Link
+          href="/portal/warranty"
+          className="inline-flex items-center text-sm font-medium text-primary hover:underline"
+        >
+          ← Back to warranty history
+        </Link>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <label htmlFor="workOrder" className="text-sm font-medium text-foreground">
+            Work order number
+          </label>
+          <input
+            id="workOrder"
+            name="workOrder"
+            type="text"
+            required
+            value={workOrderId}
+            onChange={(event) => setWorkOrderId(event.target.value)}
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            placeholder="e.g. WO-10234"
+          />
+          <p className="text-xs text-muted-foreground">Find this on the invoice or repair order we provided.</p>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="issue" className="text-sm font-medium text-foreground">
+            Describe the issue
+          </label>
+          <textarea
+            id="issue"
+            name="issue"
+            required
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            className="min-h-[120px] w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            placeholder="Share what went wrong, when you noticed it, and any supporting details."
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="attachment" className="text-sm font-medium text-foreground">
+            Attach photos or documents (optional)
+          </label>
+          <input
+            id="attachment"
+            name="attachment"
+            type="file"
+            accept="image/*,application/pdf"
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+              setAttachment(file);
+            }}
+            className="block w-full text-sm text-foreground file:mr-4 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium file:text-secondary-foreground hover:file:bg-secondary/80"
+          />
+          <p className="text-xs text-muted-foreground">Accepted formats: photos and PDF documents up to 10MB.</p>
+        </div>
+
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+          disabled={submitMutation.isLoading}
+        >
+          {submitMutation.isLoading ? "Submitting…" : "Submit claim"}
+        </button>
+
+        {submitMutation.isError && (
+          <p className="text-sm text-destructive">We couldn’t submit your claim. Please try again.</p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/warranty/[claimId]/page.tsx
+++ b/frontend/src/app/(staff)/warranty/[claimId]/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  assignWarrantyClaim,
+  fetchWarrantyClaim,
+  fetchWarrantyCommentsAfter,
+  postWarrantyComment,
+  updateWarrantyClaimStatus,
+  WarrantyClaimDetail,
+  WarrantyComment,
+  WarrantyStatus,
+} from "@/services/warranty";
+import { useTechnicianOptions } from "@/hooks/use-dashboard-data";
+import { showToast } from "@/stores/toast-store";
+import { computeSlaBadge, getNextWarrantyStatus, mergeWarrantyComments } from "@/lib/warranty-utils";
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+function SlaBadge({ detail }: { detail?: WarrantyClaimDetail | null }) {
+  const badge = useMemo(
+    () => (detail ? computeSlaBadge({ createdAt: detail.claim.createdAt, firstResponseAt: detail.claim.firstResponseAt }) : null),
+    [detail?.claim.createdAt, detail?.claim.firstResponseAt],
+  );
+  if (!badge) {
+    return null;
+  }
+
+  const toneClass: Record<string, string> = {
+    success: "bg-emerald-100 text-emerald-800",
+    destructive: "bg-red-100 text-red-700",
+    warning: "bg-amber-100 text-amber-800",
+    muted: "bg-slate-200 text-slate-700",
+  };
+
+  return <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${toneClass[badge.tone]}`}>{badge.label}</span>;
+}
+
+export default function WarrantyClaimDetailPage() {
+  const params = useParams<{ claimId: string }>();
+  const claimId = typeof params.claimId === "string" ? params.claimId : Array.isArray(params.claimId) ? params.claimId[0] : "";
+  const queryClient = useQueryClient();
+
+  const detailQuery = useQuery({
+    queryKey: ["warranty", "claim", claimId],
+    queryFn: () => fetchWarrantyClaim(claimId),
+    enabled: Boolean(claimId),
+  });
+
+  const [thread, setThread] = useState<WarrantyComment[]>([]);
+  const [commentDraft, setCommentDraft] = useState("");
+  const technicians = useTechnicianOptions();
+
+  useEffect(() => {
+    if (detailQuery.data?.comments) {
+      setThread(detailQuery.data.comments);
+    }
+  }, [detailQuery.data?.comments]);
+
+  const latestTimestamp = thread.at(-1)?.createdAt ?? detailQuery.data?.claim.createdAt ?? null;
+
+  useEffect(() => {
+    if (!claimId || !latestTimestamp) {
+      return undefined;
+    }
+    const interval = setInterval(async () => {
+      try {
+        const updates = await fetchWarrantyCommentsAfter(claimId, latestTimestamp);
+        if (updates.length > 0) {
+          setThread((current) => mergeWarrantyComments(current, updates));
+          showToast({
+            title: "New warranty comment",
+            description: "A customer has replied on this claim.",
+          });
+        }
+      } catch (error) {
+        console.error("Failed to poll comments", error);
+      }
+    }, 15_000);
+
+    return () => clearInterval(interval);
+  }, [claimId, latestTimestamp]);
+
+  const assignMutation = useMutation({
+    mutationFn: ({ userId }: { userId: string }) => assignWarrantyClaim(claimId, { userId }),
+    onSuccess: () => {
+      showToast({ title: "Claim assigned", description: "Assignment saved", variant: "success" });
+      queryClient.invalidateQueries({ queryKey: ["warranty", "claim", claimId] });
+      queryClient.invalidateQueries({ queryKey: ["warranty", "claims"] });
+    },
+    onError: (error) => {
+      const message =
+        typeof error === "object" && error !== null && "message" in error
+          ? String((error as { message?: unknown }).message ?? "Unable to assign claim")
+          : "Unable to assign claim";
+      showToast({ title: "Assignment failed", description: message, variant: "destructive" });
+    },
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: (status: WarrantyStatus) => updateWarrantyClaimStatus(claimId, { status }),
+    onSuccess: () => {
+      showToast({ title: "Status updated", description: "Claim status saved", variant: "success" });
+      queryClient.invalidateQueries({ queryKey: ["warranty", "claim", claimId] });
+      queryClient.invalidateQueries({ queryKey: ["warranty", "claims"] });
+    },
+    onError: () => {
+      showToast({ title: "Update failed", description: "Could not update status", variant: "destructive" });
+    },
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: (message: string) => postWarrantyComment(claimId, message),
+    onSuccess: (_, message) => {
+      showToast({ title: "Comment sent", description: "Customer will be notified", variant: "success" });
+      setCommentDraft("");
+      setThread((current) => [
+        ...current,
+        {
+          id: `local-${Date.now()}`,
+          claimId,
+          message,
+          sender: "STAFF",
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+    },
+    onError: () => {
+      showToast({ title: "Comment failed", description: "Unable to send reply", variant: "destructive" });
+    },
+  });
+
+  if (!claimId) {
+    return <p className="text-sm text-destructive">Invalid claim reference.</p>;
+  }
+
+  if (detailQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading claim details…</p>;
+  }
+
+  if (detailQuery.isError || !detailQuery.data) {
+    return <p className="text-sm text-destructive">Unable to load claim detail.</p>;
+  }
+
+  const { claim } = detailQuery.data;
+  const assignedOption = claim.assignedTo?.id ?? "";
+
+  return (
+    <div className="space-y-6">
+      <Link href="/warranty" className="inline-flex items-center text-sm font-medium text-primary hover:underline">
+        ← Back to triage
+      </Link>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Claim #{claim.id}</h1>
+          <p className="text-sm text-muted-foreground">Opened {formatDate(claim.createdAt)}</p>
+        </div>
+        <SlaBadge detail={detailQuery.data} />
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-6">
+          <article className="rounded-lg border border-border/60 bg-card/80 p-4 text-sm shadow-sm">
+            <h2 className="text-lg font-semibold text-foreground">Issue summary</h2>
+            <p className="mt-2 whitespace-pre-line text-muted-foreground">{claim.description ?? "No description provided."}</p>
+            {claim.attachmentUrl && (
+              <a
+                href={claim.attachmentUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline"
+              >
+                View attachment
+              </a>
+            )}
+          </article>
+
+          <article className="space-y-4 rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+            <header>
+              <h2 className="text-lg font-semibold text-foreground">Conversation</h2>
+              <p className="text-xs text-muted-foreground">
+                Messages appear newest at the bottom. The thread refreshes every 15 seconds.
+              </p>
+            </header>
+            <ul className="space-y-3 text-sm">
+              {thread.map((comment) => (
+                <li
+                  key={comment.id}
+                  className={`rounded-md border border-border/40 p-3 ${
+                    comment.sender === "STAFF" ? "bg-primary/5 text-foreground" : "bg-amber-50 text-foreground"
+                  }`}
+                >
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{comment.sender === "STAFF" ? "Staff" : "Customer"}</span>
+                    <span>{formatDate(comment.createdAt)}</span>
+                  </div>
+                  <p className="mt-2 whitespace-pre-line text-sm">{comment.message}</p>
+                </li>
+              ))}
+              {thread.length === 0 && (
+                <li className="rounded-md border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+                  No conversation yet. Send a reply to start the thread.
+                </li>
+              )}
+            </ul>
+            <form
+              className="space-y-2"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!commentDraft.trim()) {
+                  return;
+                }
+                commentMutation.mutate(commentDraft.trim());
+              }}
+            >
+              <label htmlFor="reply" className="text-sm font-medium text-foreground">
+                Reply to customer
+              </label>
+              <textarea
+                id="reply"
+                value={commentDraft}
+                onChange={(event) => setCommentDraft(event.target.value)}
+                className="min-h-[120px] w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Share troubleshooting steps or request more information."
+              />
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+                disabled={commentMutation.isLoading}
+              >
+                {commentMutation.isLoading ? "Sending…" : "Send reply"}
+              </button>
+            </form>
+          </article>
+        </div>
+
+        <aside className="space-y-4 text-sm">
+          <section className="rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+            <h2 className="text-base font-semibold text-foreground">Assignment</h2>
+            <p className="text-xs text-muted-foreground">Assign the claim to a team member for follow-up.</p>
+            <select
+              value={assignedOption}
+              onChange={(event) => {
+                const userId = event.target.value;
+                if (!userId) {
+                  return;
+                }
+                assignMutation.mutate({ userId });
+              }}
+              className="mt-3 w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">Select team member</option>
+              {technicians.data?.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </section>
+
+          <section className="space-y-3 rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h2 className="text-base font-semibold text-foreground">Status</h2>
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                {claim.status.replace(/_/g, " ")}
+              </span>
+            </div>
+            <div className="space-y-2 text-xs text-muted-foreground">
+              <p>Resolution notes: {claim.resolutionNotes ?? "—"}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {["APPROVED", "DENIED", "NEEDS_MORE_INFO", "OPEN"].map((status) => (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() => {
+                    const next = getNextWarrantyStatus(claim.status, status);
+                    if (next === claim.status && status !== claim.status) {
+                      showToast({
+                        title: "Status unchanged",
+                        description: "Cannot transition directly between approved and denied.",
+                        variant: "warning",
+                      });
+                      return;
+                    }
+                    statusMutation.mutate(next);
+                  }}
+                  className="inline-flex flex-1 items-center justify-center rounded-md border border-border/60 px-3 py-1.5 text-xs font-medium text-foreground transition hover:border-primary hover:text-primary"
+                  disabled={statusMutation.isLoading}
+                >
+                  {status.replace(/_/g, " ")}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-2 rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+            <h2 className="text-base font-semibold text-foreground">Timeline</h2>
+            <dl className="space-y-2 text-xs text-muted-foreground">
+              <div className="flex items-center justify-between">
+                <dt>Created</dt>
+                <dd>{formatDate(claim.createdAt)}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Updated</dt>
+                <dd>{formatDate(claim.updatedAt)}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>First response</dt>
+                <dd>{formatDate(claim.firstResponseAt)}</dd>
+              </div>
+            </dl>
+          </section>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(staff)/warranty/page.tsx
+++ b/frontend/src/app/(staff)/warranty/page.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWarrantyClaims, WarrantyClaimSummary } from "@/services/warranty";
+
+const FILTERS = [
+  { label: "All", query: {} },
+  { label: "Assigned to me", query: { assigned_to_me: "true" } },
+  { label: "Unassigned", query: { unassigned: "true" } },
+  { label: "Awaiting response", query: { awaiting_response: "true" } },
+] as const;
+
+type FilterQuery = (typeof FILTERS)[number]["query"];
+
+function parseFilters(searchParams: URLSearchParams) {
+  return {
+    assigned_to_me: searchParams.get("assigned_to_me") === "true",
+    unassigned: searchParams.get("unassigned") === "true",
+    awaiting_response: searchParams.get("awaiting_response") === "true",
+  };
+}
+
+export default function WarrantyTriagePage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const paramsKey = searchParams.toString();
+  const activeFilters = useMemo(() => parseFilters(new URLSearchParams(paramsKey)), [paramsKey]);
+
+  const claimsQuery = useQuery({
+    queryKey: ["warranty", "claims", activeFilters],
+    queryFn: () => fetchWarrantyClaims(activeFilters),
+  });
+
+  const handleFilterChange = (query: FilterQuery) => {
+    const params = new URLSearchParams();
+    Object.entries(query).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      }
+    });
+    router.replace(params.size > 0 ? `${pathname}?${params.toString()}` : pathname);
+  };
+
+  const claims = claimsQuery.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Warranty triage</h1>
+        <p className="text-sm text-muted-foreground">
+          Track customer issues, assignments, and SLA risk from a single view.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {FILTERS.map((filter) => {
+            const isActive = isFilterActive(filter.query, activeFilters);
+            return (
+              <button
+                key={filter.label}
+                type="button"
+                onClick={() => handleFilterChange(filter.query)}
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition ${
+                  isActive
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-border/70 text-muted-foreground hover:border-primary/40 hover:text-primary"
+                }`}
+              >
+                {filter.label}
+              </button>
+            );
+          })}
+        </div>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {claimsQuery.isLoading && (
+          <div className="rounded-lg border border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+            Loading warranty claims…
+          </div>
+        )}
+        {claimsQuery.isError && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+            Unable to load claims. Try refreshing the page.
+          </div>
+        )}
+        {!claimsQuery.isLoading && !claimsQuery.isError && claims.length === 0 && (
+          <div className="rounded-lg border border-border/60 bg-card/80 p-6 text-sm text-muted-foreground">
+            No claims match the selected filters.
+          </div>
+        )}
+        {claims.map((claim) => (
+          <ClaimCard key={claim.id} claim={claim} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function isFilterActive(query: FilterQuery, activeFilters: ReturnType<typeof parseFilters>) {
+  const expected = {
+    assigned_to_me: Boolean(query.assigned_to_me),
+    unassigned: Boolean(query.unassigned),
+    awaiting_response: Boolean(query.awaiting_response),
+  };
+  return (
+    activeFilters.assigned_to_me === expected.assigned_to_me &&
+    activeFilters.unassigned === expected.unassigned &&
+    activeFilters.awaiting_response === expected.awaiting_response
+  );
+}
+
+function ClaimCard({ claim }: { claim: WarrantyClaimSummary }) {
+  const createdAt = claim.createdAt ? new Date(claim.createdAt) : null;
+  const status = formatStatus(claim.status);
+  const assigned =
+    claim.assignedTo?.firstName || claim.assignedTo?.lastName || claim.assignedTo?.email
+      ? [claim.assignedTo?.firstName, claim.assignedTo?.lastName].filter(Boolean).join(" ") || claim.assignedTo?.email
+      : "Unassigned";
+
+  return (
+    <article className="flex h-full flex-col justify-between rounded-lg border border-border/60 bg-card/80 p-4 shadow-sm">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between text-xs">
+          <span className="font-semibold text-foreground">Claim #{claim.id}</span>
+          <StatusBadge status={status} />
+        </div>
+        <p className="text-sm text-muted-foreground line-clamp-3">{claim.description ?? "No description provided."}</p>
+        <dl className="space-y-1 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between">
+            <dt>Opened</dt>
+            <dd>{createdAt ? createdAt.toLocaleString() : "—"}</dd>
+          </div>
+          <div className="flex items-center justify-between">
+            <dt>Assigned</dt>
+            <dd>{assigned}</dd>
+          </div>
+        </dl>
+      </div>
+      <Link
+        href={`/warranty/${claim.id}`}
+        className="mt-4 inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary hover:text-primary"
+      >
+        View details
+      </Link>
+    </article>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    Approved: "bg-emerald-100 text-emerald-800",
+    Denied: "bg-red-100 text-red-700",
+    Pending: "bg-amber-100 text-amber-800",
+    Open: "bg-slate-200 text-slate-700",
+    "Needs More Info": "bg-blue-100 text-blue-700",
+  };
+
+  const classes = map[status] ?? "bg-slate-200 text-slate-700";
+  return <span className={`inline-flex rounded-full px-2 py-1 text-[11px] font-medium ${classes}`}>{status}</span>;
+}
+
+function formatStatus(status: string) {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}

--- a/frontend/src/components/layout/staff-shell.tsx
+++ b/frontend/src/components/layout/staff-shell.tsx
@@ -6,6 +6,7 @@ import { ReactNode, useMemo, useState } from "react";
 import { clsx } from "clsx";
 
 import { useDashboardNotifications } from "@/hooks/use-dashboard-data";
+import { useWarrantyCommentNotifications } from "@/hooks/use-warranty-notifications";
 import { useSession } from "@/hooks/use-session";
 import { useLayoutStore } from "@/stores/layout-store";
 import type { DashboardNotification } from "@/services/dashboard-mappers";
@@ -16,6 +17,7 @@ const navigationByRole: Record<string, Array<{ label: string; href: string }>> =
     { label: "Manager View", href: "/dashboard/manager" },
     { label: "Invoices", href: "/invoices" },
     { label: "Inventory", href: "/inventory" },
+    { label: "Warranty", href: "/warranty" },
   ],
   MANAGER: [
     { label: "Manager Dashboard", href: "/dashboard/manager" },
@@ -23,6 +25,7 @@ const navigationByRole: Record<string, Array<{ label: string; href: string }>> =
     { label: "Admin Summary", href: "/dashboard/admin" },
     { label: "Invoices", href: "/invoices" },
     { label: "Inventory", href: "/inventory" },
+    { label: "Warranty", href: "/warranty" },
   ],
   ADMIN: [
     { label: "Admin Dashboard", href: "/dashboard/admin" },
@@ -30,6 +33,7 @@ const navigationByRole: Record<string, Array<{ label: string; href: string }>> =
     { label: "Technician Dashboard", href: "/dashboard" },
     { label: "Invoices", href: "/invoices" },
     { label: "Inventory", href: "/inventory" },
+    { label: "Warranty", href: "/warranty" },
   ],
 };
 
@@ -73,6 +77,9 @@ export function StaffShell({ children }: StaffShellProps) {
       { label: "Invoices", href: "/invoices" },
     ];
   const { data: notifications } = useDashboardNotifications(role ?? null);
+  const warrantyEnabled = role ? ["ADMIN", "MANAGER", "FRONT_DESK"].includes(role) : false;
+  const warrantyNotificationsQuery = useWarrantyCommentNotifications(warrantyEnabled);
+  const combinedNotifications = [...(notifications ?? []), ...(warrantyNotificationsQuery.data ?? [])];
 
   if (!isAuthenticated && !isLoading) {
     router.replace("/login");
@@ -111,7 +118,7 @@ export function StaffShell({ children }: StaffShellProps) {
           </div>
           <div className="flex items-center gap-4">
             <Breadcrumbs items={breadcrumbs} />
-            <NotificationCenter notifications={notifications ?? []} />
+            <NotificationCenter notifications={combinedNotifications} />
             {isAuthenticated && (
               <div className="hidden flex-col text-xs leading-tight sm:flex">
                 <span className="font-semibold text-foreground">{user?.email}</span>

--- a/frontend/src/hooks/use-warranty-notifications.ts
+++ b/frontend/src/hooks/use-warranty-notifications.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import type { DashboardNotification } from "@/services/dashboard-mappers";
+import { fetchWarrantyAwaitingResponse } from "@/services/warranty";
+import { showToast } from "@/stores/toast-store";
+
+export function useWarrantyCommentNotifications(enabled: boolean) {
+  const query = useQuery({
+    queryKey: ["warranty", "notifications"],
+    queryFn: async () => {
+      const claims = await fetchWarrantyAwaitingResponse();
+      return claims.map<DashboardNotification>((claim) => ({
+        id: `warranty-${claim.id}`,
+        title: `Awaiting response (#${claim.id})`,
+        description: claim.customer?.email
+          ? `Customer ${claim.customer.email} is waiting for a reply`
+          : "Customer is awaiting a reply",
+        severity: "warning",
+      }));
+    },
+    enabled,
+    refetchInterval: 30_000,
+  });
+
+  const previousCount = useRef(0);
+  const currentCount = query.data?.length ?? 0;
+
+  useEffect(() => {
+    if (!enabled) {
+      previousCount.current = 0;
+      return;
+    }
+
+    if (currentCount > previousCount.current) {
+      showToast({
+        title: "New warranty replies awaiting",
+        description: `${currentCount} claim${currentCount === 1 ? "" : "s"} need attention`,
+        variant: "warning",
+      });
+    }
+
+    previousCount.current = currentCount;
+  }, [currentCount, enabled]);
+
+  return { ...query, data: query.data ?? [] } as typeof query & { data: DashboardNotification[] };
+}

--- a/frontend/src/lib/__tests__/warranty-utils.test.ts
+++ b/frontend/src/lib/__tests__/warranty-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeSlaBadge,
+  getNextWarrantyStatus,
+  mergeWarrantyComments,
+} from "@/lib/warranty-utils";
+
+describe("computeSlaBadge", () => {
+  it("returns null when createdAt missing", () => {
+    expect(computeSlaBadge({})).toBeNull();
+  });
+
+  it("flags breached SLA when no response for over 48h", () => {
+    const createdAt = new Date("2024-01-01T00:00:00Z");
+    const now = new Date(createdAt.getTime() + 49 * 3_600_000);
+    const badge = computeSlaBadge({ createdAt: createdAt.toISOString() }, now);
+    expect(badge).toEqual({ label: "SLA breached", tone: "destructive" });
+  });
+
+  it("computes response time when firstResponseAt is provided", () => {
+    const createdAt = new Date("2024-01-01T00:00:00Z");
+    const firstResponse = new Date(createdAt.getTime() + 3.5 * 3_600_000);
+    const badge = computeSlaBadge({
+      createdAt: createdAt.toISOString(),
+      firstResponseAt: firstResponse.toISOString(),
+    });
+    expect(badge).toEqual({ label: "Responded in 3.5h", tone: "success" });
+  });
+});
+
+describe("mergeWarrantyComments", () => {
+  it("deduplicates comments and keeps chronological order", () => {
+    const existing = [
+      { id: "a", createdAt: "2024-01-01T00:00:00Z" },
+      { id: "b", createdAt: "2024-01-01T01:00:00Z" },
+    ];
+    const incoming = [
+      { id: "b", createdAt: "2024-01-01T01:00:00Z" },
+      { id: "c", createdAt: "2024-01-01T00:30:00Z" },
+    ];
+    const merged = mergeWarrantyComments(existing, incoming);
+    expect(merged.map((item) => item.id)).toEqual(["a", "c", "b"]);
+  });
+});
+
+describe("getNextWarrantyStatus", () => {
+  it("prevents flipping directly between approved and denied", () => {
+    expect(getNextWarrantyStatus("APPROVED", "DENIED")).toBe("APPROVED");
+    expect(getNextWarrantyStatus("DENIED", "APPROVED")).toBe("DENIED");
+  });
+
+  it("allows transitions to valid targets", () => {
+    expect(getNextWarrantyStatus("OPEN", "NEEDS_MORE_INFO")).toBe("NEEDS_MORE_INFO");
+  });
+
+  it("ignores invalid statuses", () => {
+    expect(getNextWarrantyStatus("OPEN", "custom" as unknown as string)).toBe("OPEN");
+  });
+});

--- a/frontend/src/lib/warranty-utils.ts
+++ b/frontend/src/lib/warranty-utils.ts
@@ -1,0 +1,94 @@
+export type WarrantySlaTone = "success" | "warning" | "destructive" | "muted";
+
+export type WarrantySlaBadge = {
+  label: string;
+  tone: WarrantySlaTone;
+};
+
+export type WarrantyTimelineLike = {
+  createdAt?: string | null;
+  firstResponseAt?: string | null;
+};
+
+export type WarrantyCommentLike = {
+  id: string;
+  createdAt: string;
+};
+
+const SLA_HOURS = 48;
+
+export function computeSlaBadge(claim: WarrantyTimelineLike, referenceDate: Date = new Date()): WarrantySlaBadge | null {
+  if (!claim.createdAt) {
+    return null;
+  }
+
+  const createdAt = new Date(claim.createdAt);
+  if (Number.isNaN(createdAt.getTime())) {
+    return null;
+  }
+
+  if (claim.firstResponseAt) {
+    const firstResponse = new Date(claim.firstResponseAt);
+    const diffHours = (firstResponse.getTime() - createdAt.getTime()) / 3_600_000;
+    if (Number.isFinite(diffHours) && diffHours > SLA_HOURS) {
+      return { label: `First response after SLA (${diffHours.toFixed(1)}h)`, tone: "destructive" };
+    }
+    if (Number.isFinite(diffHours) && diffHours >= 0) {
+      return { label: `Responded in ${diffHours.toFixed(1)}h`, tone: "success" };
+    }
+  }
+
+  const hoursOpen = (referenceDate.getTime() - createdAt.getTime()) / 3_600_000;
+  if (!Number.isFinite(hoursOpen)) {
+    return null;
+  }
+
+  if (hoursOpen > SLA_HOURS) {
+    return { label: "SLA breached", tone: "destructive" };
+  }
+
+  if (hoursOpen > SLA_HOURS - 12) {
+    return { label: "At risk", tone: "warning" };
+  }
+
+  return { label: "Within SLA", tone: "muted" };
+}
+
+export function mergeWarrantyComments<T extends WarrantyCommentLike>(existing: T[], incoming: T[]): T[] {
+  if (incoming.length === 0) {
+    return existing;
+  }
+
+  const seen = new Set(existing.map((comment) => comment.id));
+  const merged = [...existing];
+
+  for (const comment of incoming) {
+    if (seen.has(comment.id)) {
+      continue;
+    }
+    seen.add(comment.id);
+    merged.push(comment);
+  }
+
+  return merged.sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+}
+
+export function getNextWarrantyStatus(current: string, desired: string): string {
+  const normalized = desired.toUpperCase();
+  const allowed = new Set(["APPROVED", "DENIED", "NEEDS_MORE_INFO", "OPEN", "PENDING"]);
+  if (!allowed.has(normalized)) {
+    return current;
+  }
+
+  if (current === "APPROVED" && normalized === "DENIED") {
+    return current;
+  }
+
+  if (current === "DENIED" && normalized === "APPROVED") {
+    return current;
+  }
+
+  return normalized;
+}

--- a/frontend/src/services/warranty.ts
+++ b/frontend/src/services/warranty.ts
@@ -1,0 +1,150 @@
+import { AxiosRequestConfig } from "axios";
+
+import { apiClient, get, post, put } from "@/lib/api/client";
+
+export type WarrantyClaimSummary = {
+  id: string;
+  status: string;
+  description?: string | null;
+  resolutionNotes?: string | null;
+  workOrderId?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  firstResponseAt?: string | null;
+  attachmentUrl?: string | null;
+  customer?: {
+    id: string;
+    email?: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null;
+  assignedTo?: {
+    id: string;
+    email?: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null;
+};
+
+export type WarrantyComment = {
+  id: string;
+  claimId: string;
+  message: string;
+  sender: "CUSTOMER" | "STAFF";
+  createdAt: string;
+};
+
+export type WarrantyAuditLog = {
+  id: string;
+  claimId?: string | null;
+  actorId?: string | null;
+  action: string;
+  detail?: string | null;
+  timestamp: string;
+};
+
+export type WarrantyClaimDetail = {
+  claim: WarrantyClaimSummary;
+  comments: WarrantyComment[];
+  audit_log: WarrantyAuditLog[];
+};
+
+export type WarrantyClaimFilters = {
+  assigned_to_me?: boolean;
+  unassigned?: boolean;
+  awaiting_response?: boolean;
+};
+
+export type SubmitWarrantyClaimInput = {
+  workOrderId: string;
+  description: string;
+  attachment?: File | null;
+};
+
+export type WarrantyStatus = "APPROVED" | "DENIED" | "PENDING" | "OPEN" | "NEEDS_MORE_INFO";
+
+export type UpdateWarrantyStatusInput = {
+  status: WarrantyStatus;
+  resolutionNotes?: string;
+};
+
+export type AssignWarrantyClaimInput = {
+  userId: string;
+};
+
+export async function submitWarrantyClaim(payload: SubmitWarrantyClaimInput) {
+  const formData = new FormData();
+  formData.append("work_order_id", payload.workOrderId);
+  formData.append("description", payload.description);
+
+  if (payload.attachment) {
+    formData.append("file", payload.attachment);
+  }
+
+  const config: AxiosRequestConfig = {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  };
+
+  const response = await apiClient.post<{ message: string; claim?: WarrantyClaimSummary }>(
+    "/warranty/warranty",
+    formData,
+    config,
+  );
+  return response.data;
+}
+
+export async function fetchWarrantyClaims(filters: WarrantyClaimFilters = {}) {
+  const params = new URLSearchParams();
+  if (filters.assigned_to_me) {
+    params.set("assigned_to_me", "true");
+  }
+  if (filters.unassigned) {
+    params.set("unassigned", "true");
+  }
+  if (filters.awaiting_response) {
+    params.set("awaiting_response", "true");
+  }
+
+  const query = params.toString();
+  const url = query ? `/warranty/warranty?${query}` : "/warranty/warranty";
+  return get<WarrantyClaimSummary[]>(url);
+}
+
+export async function fetchWarrantyClaim(claimId: string) {
+  return get<WarrantyClaimDetail>(`/warranty/warranty/${claimId}`);
+}
+
+export async function updateWarrantyClaimStatus(claimId: string, input: UpdateWarrantyStatusInput) {
+  return put(`/warranty/warranty/${claimId}/status`, {
+    status: input.status,
+    resolution_notes: input.resolutionNotes ?? null,
+  });
+}
+
+export async function assignWarrantyClaim(claimId: string, input: AssignWarrantyClaimInput) {
+  return put(`/warranty/warranty/${claimId}/assign`, {
+    user_id: input.userId,
+  });
+}
+
+export async function postWarrantyComment(claimId: string, message: string) {
+  return post(`/warranty/warranty/${claimId}/comment`, {
+    message,
+  });
+}
+
+export async function fetchWarrantyCommentsAfter(claimId: string, since: string) {
+  const params = new URLSearchParams({ since });
+  return get<WarrantyComment[]>(`/warranty/warranty/${claimId}/comments/after?${params.toString()}`);
+}
+
+export async function fetchWarrantyUnreadCount(claimId: string, lastViewed: string) {
+  const params = new URLSearchParams({ last_viewed: lastViewed });
+  return get<{ unread_count: number }>(`/warranty/warranty/${claimId}/unread?${params.toString()}`);
+}
+
+export async function fetchWarrantyAwaitingResponse() {
+  return fetchWarrantyClaims({ awaiting_response: true });
+}

--- a/frontend/tests/warranty.spec.ts
+++ b/frontend/tests/warranty.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+import { apiClient } from "@/lib/api/client";
+import { submitWarrantyClaim } from "@/services/warranty";
+
+test.describe("warranty portal uploads", () => {
+  test("includes attachment when submitting a claim", async () => {
+    const file = new File(["sample"], "evidence.txt", { type: "text/plain" });
+    let received: FormData | null = null;
+
+    const originalPost = apiClient.post.bind(apiClient);
+    (apiClient as unknown as { post: typeof apiClient.post }).post = async (url, data, config) => {
+      received = data as FormData;
+      expect(url).toBe("/warranty/warranty");
+      expect(config?.headers?.["Content-Type"]).toContain("multipart/form-data");
+      return { data: { message: "ok" } } as unknown as Awaited<ReturnType<typeof originalPost>>;
+    };
+
+    try {
+      await submitWarrantyClaim({ workOrderId: "WO-42", description: "Brake noise", attachment: file });
+    } finally {
+      (apiClient as unknown as { post: typeof apiClient.post }).post = originalPost;
+    }
+
+    expect(received).not.toBeNull();
+    const entries = Array.from(received!.entries());
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        ["work_order_id", "WO-42"],
+        ["description", "Brake noise"],
+      ]),
+    );
+    const fileEntry = entries.find(([key]) => key === "file");
+    expect(fileEntry).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add a customer warranty submission form with file uploads, validation, and success feedback
- create staff warranty triage and claim detail experiences with SLA badges, assignments, and threaded comment polling
- extend warranty service utilities plus unit and Playwright coverage for status transitions and upload handling

## Testing
- not run (npm install repeatedly failed due to registry corruption in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e85b6bbe04832cb6658a094e06ba29